### PR TITLE
Add nimbus project to ecosystem projects list.

### DIFF
--- a/utils/constants.py
+++ b/utils/constants.py
@@ -4,7 +4,8 @@ PLATFORM = [
 ]
 
 PROJECTS_ECOSYSTEM = [
-    'experimenter'
+    'experimenter',
+    'nimbus'
 ]
 
 PROJECTS_MOBILE = [


### PR DESCRIPTION
This just adds the nimbus project to the support projects list. 

Maybe we could think of a way of supporting an external file that can be read to allow for easier project additions in the future.