### PR TITLE
Fix testcase coverage report

### DIFF
--- a/lib/testrail_conn.py
+++ b/lib/testrail_conn.py
@@ -40,6 +40,19 @@ class APIClient:
         """
         return self.__send_request('GET', uri, filepath)
 
+    def send_get_milestones(self, uri, filepath=None):
+        """Issue a GET request (read) against the API.
+
+        Args:
+            uri: The API method to call including parameters, e.g. get_case/1.
+            filepath: The path and file name for attachment download; used only
+                for 'get_attachment/:attachment_id'.
+
+        Returns:
+            A dict containing the result of the request.
+        """
+        return self.__send_request_milestones('GET', uri, filepath)
+
     def send_post(self, uri, data):
         """Issue a POST request (write) against the API.
 
@@ -84,7 +97,6 @@ class APIClient:
             while True:
                 response = requests.get(f"{url}&limit={limit}&offset={offset}", headers=headers)
                 data = response.json()
-                print(data)
 
                 # Check if 'cases' key exists in the response
                 if 'cases' in data:
@@ -93,6 +105,65 @@ class APIClient:
                     # Break if fewer items are returned than the limit, indicating the last page
                     if len(data['cases']) < limit:
                         break
+                else:
+                    all_items = data
+                    break  # If 'cases' key is not present, exit the loop
+
+                offset += limit
+
+            return all_items
+
+        if response.status_code > 201:
+            try:
+                error = response.json()
+            except requests.exceptions.HTTPError:     # response.content not formatted as JSON
+                error = str(response.content)
+            raise APIError('TestRail API returned HTTP %s (%s)' % (response.status_code, error))
+        else:
+            if uri[:15] == 'get_attachment/':   # Expecting file, not JSON
+                try:
+                    open(data, 'wb').write(response.content)
+                    return (data)
+                except FileNotFoundError:
+                    return ("Error saving attachment.")
+            else:
+                try:
+                    return response.json()
+                except requests.exceptions.HTTPError: 
+                    return {}
+
+    def __send_request_milestones(self, method, uri, data):
+        url = self.__url + uri
+
+        auth = str(
+            base64.b64encode(
+                bytes('%s:%s' % (self.user, self.password), 'utf-8')
+            ),
+            'ascii'
+        ).strip()
+        headers = {'Authorization': 'Basic ' + auth}
+
+        if method == 'POST':
+            if uri[:14] == 'add_attachment':    # add_attachment API method
+                files = {'attachment': (open(data, 'rb'))}
+                response = requests.post(url, headers=headers, files=files)
+                files['attachment'].close()
+            else:
+                headers['Content-Type'] = 'application/json'
+                payload = bytes(json.dumps(data), 'utf-8')
+                response = requests.post(url, headers=headers, data=payload)
+        else:
+            all_items = []
+            offset = 0
+            limit = 250
+
+            headers['Content-Type'] = 'application/json'
+
+            while True:
+                response = requests.get(f"{url}&limit={limit}&offset={offset}", headers=headers)
+                data = response.json()
+
+                # Check if 'milestones' key exists in the response
                 if 'milestones' in data:
                     all_items.extend(data['milestones'])
 
@@ -125,6 +196,7 @@ class APIClient:
                     return response.json()
                 except requests.exceptions.HTTPError: 
                     return {}
+
 
 
 class APIError(Exception):

--- a/testrail.py
+++ b/testrail.py
@@ -34,7 +34,7 @@ class TestRail:
     # API: Milestones
     # https://mozilla.testrail.io/index.php?/api/v2/get_milestones/59
     def milestones(self, testrail_project_id):
-        return self.client.send_get(
+        return self.client.send_get_milestones(
             'get_milestones/{0}'.format(testrail_project_id))
 
     # API: Projects
@@ -105,7 +105,7 @@ class TestRailClient(TestRail):
 
         # Test suite data is dynamic. Wipe out old test suite data
         # in database before updating.
-        self.db.test_suites_delete()
+        # self.db.test_suites_delete()
 
         for project_ids in project_ids_list:
             projects_id = project_ids[0]


### PR DESCRIPTION
There is an error in getting the cases for the test suites when we add the milestones in the same get request.
Looks like iterating when there is pagination does not work. Not sure why the data is not correctly retrieved. If we have different get requests for each case, then everything works fine.

While I investigate how to add everything to the same query, I'm creating the PR with the longest solution that duplicates code but it at least is working.