### PR TITLE
Bugfix MTE-4454 Handle patch release version number

### DIFF
--- a/api_sentry.py
+++ b/api_sentry.py
@@ -121,7 +121,8 @@ class DatabaseSentry():
     def _all_new_production_dot_versions(self, versions):
         major_versions = []
         for version in versions:
-            major, minor = version.split('.')
+            parts = version.split('.')
+            major = parts[0]
             major_versions.append(major)
         major_versions = sorted(list(set(major_versions)), reverse=True)
         major_versions = major_versions[:NUM_MAJOR_VERSIONS]


### PR DESCRIPTION
`139.0.1` has been available as a release. The existing code assume that a release is just major dot minor. Let me remove that restriction because I just need the major version number in this snippet of code.

https://github.com/mozilla-mobile/testops-dashboard/actions/runs/14781695734/job/41501825115