### PR TITLE
Add Mozilla Public License comment

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -1,3 +1,9 @@
+#! /usr/bin/env python3
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import argparse
 import sys
 

--- a/api_bitrise.py
+++ b/api_bitrise.py
@@ -1,3 +1,9 @@
+#! /usr/bin/env python3
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import sys
 import os
 

--- a/api_bugzilla.py
+++ b/api_bugzilla.py
@@ -1,3 +1,9 @@
+#! /usr/bin/env python3
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import pandas as pd
 
 from constants import PRODUCTS, FIELDS

--- a/api_confluence.py
+++ b/api_confluence.py
@@ -1,3 +1,9 @@
+#! /usr/bin/env python3
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import os
 import glob
 import json

--- a/api_github.py
+++ b/api_github.py
@@ -1,3 +1,9 @@
+#! /usr/bin/env python3
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import requests
 
 from database import (

--- a/api_jira.py
+++ b/api_jira.py
@@ -1,3 +1,9 @@
+#! /usr/bin/env python3
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import os
 import sys
 

--- a/api_looker.py
+++ b/api_looker.py
@@ -1,3 +1,9 @@
+#! /usr/bin/env python3
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import requests
 import time
 import re

--- a/api_sentry.py
+++ b/api_sentry.py
@@ -1,3 +1,9 @@
+#! /usr/bin/env python3
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import os
 import sys
 

--- a/api_testrail.py
+++ b/api_testrail.py
@@ -1,3 +1,9 @@
+#! /usr/bin/env python3
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import os
 import sys
 

--- a/constants.py
+++ b/constants.py
@@ -1,3 +1,9 @@
+#! /usr/bin/env python3
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 PLATFORMS = [
     'desktop',
     'ecosystem',

--- a/database.py
+++ b/database.py
@@ -1,3 +1,9 @@
+#! /usr/bin/env python3
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 from sqlalchemy import Table
 
 from lib.database_conn import Session, Base

--- a/lib/bitrise_conn.py
+++ b/lib/bitrise_conn.py
@@ -1,3 +1,9 @@
+#! /usr/bin/env python3
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import logging
 import requests
 

--- a/lib/database_conn.py
+++ b/lib/database_conn.py
@@ -1,3 +1,9 @@
+#! /usr/bin/env python3
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 """Base database connector module
 https://github.com/swaathi/sqlalchemy"""
 

--- a/lib/github_pull_counts.py
+++ b/lib/github_pull_counts.py
@@ -1,3 +1,9 @@
+#! /usr/bin/env python3
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 # flake8: noqa
 import os
 import sys

--- a/lib/jira_conn.py
+++ b/lib/jira_conn.py
@@ -1,3 +1,9 @@
+#! /usr/bin/env python3
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 """Jira API binding for Python 3.x
 
 Learn more:

--- a/lib/sentry_conn.py
+++ b/lib/sentry_conn.py
@@ -1,3 +1,9 @@
+#! /usr/bin/env python3
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import requests
 
 

--- a/lib/testrail_conn.py
+++ b/lib/testrail_conn.py
@@ -1,3 +1,9 @@
+#! /usr/bin/env python3
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 # flake8: noqa
 """TestRail API binding for Python 3.x.
 


### PR DESCRIPTION
Following up to the [comment](https://github.com/mozilla-mobile/testops-dashboard/pull/102#discussion_r2089675322) from @AaronMT , let's add the licensing information on all Python file for consistency.

This change should not affect the existing functionalities. See
https://github.com/mozilla-mobile/testops-dashboard/actions/runs/15171014370/job/42660755921