### PR TITLE
Remove Mozilla license from testrail_conn.py

### DIFF
--- a/lib/testrail_conn.py
+++ b/lib/testrail_conn.py
@@ -1,9 +1,3 @@
-#! /usr/bin/env python3
-
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
 # flake8: noqa
 """TestRail API binding for Python 3.x.
 


### PR DESCRIPTION
We imported this file from TestRail and use it in our work.