### PR TITLE
Sentry run in github action for crash free rates

### DIFF
--- a/.github/workflows/production-daily.yml
+++ b/.github/workflows/production-daily.yml
@@ -86,8 +86,13 @@ jobs:
 
         continue-on-error: true
 
-      - name: Sentry query
+      - name: Sentry query Issues
         run: python __main__.py --report-type sentry-issues
+
+        continue-on-error: true
+
+      - name: Sentry query Crash Free Rate
+        run: python __main__.py --report-type sentry-crash-free-rates
 
         continue-on-error: true
 


### PR DESCRIPTION
We need to start gathering sentry crash free rates daily and so, we need the github action to add that call