### PR TITLE
Change charset to handle emojis in issues

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -410,7 +410,7 @@ CREATE TABLE `report_sentry_issues` (
   `release_version` varchar(250) NOT NULL,
   `permalink` varchar(250) NOT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=8461 DEFAULT CHARSET=utf8mb3;
+) ENGINE=InnoDB AUTO_INCREMENT=8461 DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 DROP TABLE IF EXISTS `report_sentry_crash_free_rate`;


### PR DESCRIPTION
When the issues contain emojis, the code fails to insert the issues into the database:

https://github.com/mozilla-mobile/testops-dashboard/actions/runs/15196729876/job/42742539839

```
  File "/opt/hostedtoolcache/Python/3.13.3/x64/lib/python3.13/site-packages/pymysql/err.py", line 150, in raise_mysql_exception
    raise errorclass(errno, errval)
sqlalchemy.exc.DataError: (pymysql.err.DataError) (1366, "Incorrect string value: '\\xF0\\x9F\\xA4\\xAF >...' for column 'title' at row 1")
[SQL: INSERT INTO report_sentry_issues (sentry_id, culprit, title, count, user_count, release_version, permalink) VALUES (%(sentry_id)s, %(culprit)s, %(title)s, %(count)s, %(user_count)s, %(release_version)s, %(permalink)s)]
[parameters: ***'sentry_id': '6622746608', 'culprit': 'TabsButton.updateTabCount', 'title': 'EXC_BAD_ACCESS: __baseAttributedString > 🤯 > dyld_v1   arm64 > sb_containsEmoji >', 'count': '1', 'user_count': 1, 'release_version': '138.1', 'permalink': 'https://***.sentry.io/issues/6622746608/'***]
(Background on this error at: https://sqlalche.me/e/14/9h9h)
Error: Process completed with exit code 1.
```

A way to handle emojis such as 🤯 is to update the charset. `utf8mb4` should handle emojis.

I have used `utf8mb4` for the crash rates table for a few days without issues.

The command to convert existing table's charset is the following:
```
alter table `report_sentry_issues` convert to character set utf8mb4 collate utf8mb4_unicode_ci;
```

I have updated the charset of the table `report_sentry_issues` from staging and production.

Inserting new issues to a test database table with charset utf8mb4 seems ok: https://github.com/mozilla-mobile/testops-dashboard/actions/runs/15645530558.