### PR TITLE
Delete MTE-4572 Remove binaries available from GCP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__*
 .DS_Store
 cloud_sql_proxy
 .python-version*
+db/cloud-sql-proxy


### PR DESCRIPTION
We should install binaries for our platforms from here:

https://cloud.google.com/sql/docs/mysql/connect-auth-proxy