### PR TITLE
Bugfix MTE-4572 Fix filename for production

### DIFF
--- a/.github/workflows/production-daily.yml
+++ b/.github/workflows/production-daily.yml
@@ -100,7 +100,7 @@ jobs:
         id: slack-sentry
         uses: slackapi/slack-github-action@v2.1.0
         with:
-          payload-file-path: "./sentry_slack.json"
+          payload-file-path: "./sentry-slack.json"
           payload-templated: true 
           webhook:  ${{ secrets.SLACK_WEBHOOK_URL_TEST_ALERTS_SANDBOX }}
           webhook-type: incoming-webhook


### PR DESCRIPTION
The daily production job did not send a Slack notification:
https://github.com/mozilla-mobile/testops-dashboard/actions/runs/15727318125/job/44319977874

The filename (as seen in staging-push.yml) is `sentry-slack.json`, not `sentry_slack.json`.