### PR TITLE
Bugfix Handle error and empty responses from REST API

### DIFF
--- a/api_sentry.py
+++ b/api_sentry.py
@@ -280,22 +280,29 @@ class DatabaseSentry:
         response_adoption_rate,
         release_version
     ):
-        crash_free_rate_session = (
-            response_crash_free_rate_session['groups'][0]['totals'].get(
-                'crash_free_rate(session)', None
+        crash_free_rate_session = None
+        if response_crash_free_rate_session:
+            crash_free_rate_session = (
+                response_crash_free_rate_session['groups'][0]['totals'].get(
+                    'crash_free_rate(session)', None
+                )
             )
-        )
-        crash_free_rate_user = (
-            response_crash_free_rate_user['groups'][0]['totals'].get(
-                'crash_free_rate(user)', None
+        crash_free_rate_user = None
+        if response_crash_free_rate_user:
+            crash_free_rate_user = (
+                response_crash_free_rate_user['groups'][0]['totals'].get(
+                    'crash_free_rate(user)', None
+                )
             )
-        )
         # Sometimes the REST API calls return null values in the field
         # Return None if either rate is null
-        adoption_rate_user = (
-            response_adoption_rate['projects'][0]['healthData']
-            .get('adoption', 0) or 0.0
-        )
+        adoption_rate_user = None
+        if response_adoption_rate:
+            adoption_rate_user = (
+                response_adoption_rate['projects'][0]['healthData']
+                .get('adoption', 0) or 0.0
+            )
+
         if (
             crash_free_rate_session is not None
             and crash_free_rate_user is not None

--- a/api_sentry.py
+++ b/api_sentry.py
@@ -303,20 +303,21 @@ class DatabaseSentry:
                 .get('adoption', 0) or 0.0
             )
 
-        if (
-            crash_free_rate_session is not None
-            and crash_free_rate_user is not None
-            and adoption_rate_user is not None
-        ):
+        # Let me use -1 to indicate null values
+        percentage_crash_free_rate_session = -1
+        if crash_free_rate_session:
             percentage_crash_free_rate_session = round(
                 crash_free_rate_session * 100, 2
             )
+        percentage_crash_free_rate_user = -1
+        if crash_free_rate_user:
             percentage_crash_free_rate_user = round(
                 crash_free_rate_user * 100, 2
             )
+        percentage_adoption_rate_user = -1
+        if adoption_rate_user:
             percentage_adoption_rate_user = round(adoption_rate_user, 2)
-        else:
-            return None
+
         now = DatetimeUtils.start_date('0')
         row = [
             percentage_crash_free_rate_session,

--- a/lib/sentry_conn.py
+++ b/lib/sentry_conn.py
@@ -8,7 +8,6 @@ import requests
 from urllib.error import HTTPError
 
 
-
 class APIClient:
     def __init__(self, base_url):
         self.api_token = ''
@@ -35,7 +34,6 @@ class APIClient:
                 response.raise_for_status()
             except HTTPError:
                 return None
-                
 
             data = response.json()
             if isinstance(data, list):

--- a/lib/sentry_conn.py
+++ b/lib/sentry_conn.py
@@ -5,6 +5,8 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import requests
+from urllib.error import HTTPError
+
 
 
 class APIClient:
@@ -29,7 +31,11 @@ class APIClient:
         while url:
             print(f"Fetching: {url}")
             response = requests.get(url, headers=headers)
-            response.raise_for_status()
+            try:
+                response.raise_for_status()
+            except HTTPError:
+                return None
+                
 
             data = response.json()
             if isinstance(data, list):

--- a/lib/sentry_conn.py
+++ b/lib/sentry_conn.py
@@ -5,7 +5,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import requests
-from urllib.error import HTTPError
+from requests.exceptions import HTTPError
 
 
 class APIClient:

--- a/lib/sentry_slack_rates.py
+++ b/lib/sentry_slack_rates.py
@@ -11,9 +11,18 @@ def insert_rates(json_data, csv_file):
         rows = csv.DictReader(file)
         for row in rows:
             print(row)
-            crash_free_rate_user = row['crash_free_rate_user']
-            crash_free_rate_session = row['crash_free_rate_session']
-            adoption_rate_user = row['adoption_rate_user']
+            crash_free_rate_user = (
+                "NaN" if float(row['crash_free_rate_user']) < 0
+                else row['crash_free_rate_user']
+            )
+            crash_free_rate_session = (
+                "NaN" if float(row['crash_free_rate_session']) < 0
+                else row['crash_free_rate_session']
+            )
+            adoption_rate_user = (
+                "NaN" if float(row['adoption_rate_user']) < 0
+                else row['adoption_rate_user']
+            )
             release_version = row['release_version']
             json_data["blocks"].append(
                 {


### PR DESCRIPTION
Some commands for querying Sentry API started to fail this morning:
https://github.com/mozilla-mobile/testops-dashboard/actions/runs/15852166348

The cause is that the REST API for querying the adoption rate for v141 returns empty. The release v141 is brand new. This PR now report empty crash free rates and adoption rates as NaN in the Slack notification.
![Screenshot 2025-06-24 at 4 27 21 PM](https://github.com/user-attachments/assets/1384cf31-eda8-4bfa-be6f-1252d62ccee6)

Here's a workflow using this branch:
https://github.com/mozilla-mobile/testops-dashboard/actions/runs/15860482383/job/44716211029