### PR TITLE
Bugfix Health info for beta versions

### DIFF
--- a/api_sentry.py
+++ b/api_sentry.py
@@ -89,12 +89,13 @@ class Sentry:
         # Long version name could be beta
         if health_info_release is None:
             return self.client.http_get(
-            (
-                "organizations/{0}/releases/org.mozilla.ios.FirefoxBeta%40{1}/"
-                "?health=1&summaryStatsPeriod=7d&project={2}"
-                "&environment=Production&adoptionStages=1"
-            ).format(self.organization_slug, release, self.project_id)
-        )
+                (
+                    "organizations/{0}/releases/"
+                    "org.mozilla.ios.FirefoxBeta%40{1}/"
+                    "?health=1&summaryStatsPeriod=7d&project={2}"
+                    "&environment=Production&adoptionStages=1"
+                ).format(self.organization_slug, release, self.project_id)
+            )
         else:
             return health_info_release
 

--- a/api_sentry.py
+++ b/api_sentry.py
@@ -79,13 +79,24 @@ class Sentry:
 
     # API: Adoption Rate (Users)
     def sentry_adoption_rate(self, release):
-        return self.client.http_get(
+        health_info_release = self.client.http_get(
             (
                 "organizations/{0}/releases/org.mozilla.ios.Firefox%40{1}/"
                 "?health=1&summaryStatsPeriod=7d&project={2}"
                 "&environment=Production&adoptionStages=1"
             ).format(self.organization_slug, release, self.project_id)
         )
+        # Long version name could be beta
+        if health_info_release is None:
+            return self.client.http_get(
+            (
+                "organizations/{0}/releases/org.mozilla.ios.FirefoxBeta%40{1}/"
+                "?health=1&summaryStatsPeriod=7d&project={2}"
+                "&environment=Production&adoptionStages=1"
+            ).format(self.organization_slug, release, self.project_id)
+        )
+        else:
+            return health_info_release
 
 
 class SentryClient(Sentry):


### PR DESCRIPTION
The adoption rate for the beta version could not be fetched because the REST API URL wasn't equipped to handle beta releases. The `releases/` endpoint uses the "long" name of the releases. The beta releases are indicated by `org.mozilla.ios.FirefoxBeta` instead of `org.mozilla.ios.Firefox`.

v141 is currently in beta. We can get the adoption rate for this version instead of `NaN`.
https://github.com/mozilla-mobile/testops-dashboard/actions/runs/15913990280
<img width="488" alt="Screenshot 2025-06-26 at 11 57 17 PM" src="https://github.com/user-attachments/assets/d1d565eb-d15a-42bf-a481-b7baf550acfc" />
