### PR TITLE
Improve and Add Bugzilla queries

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -70,3 +70,16 @@ BUGZILLA_URL = "bugzilla.mozilla.org"
 PRODUCTS = ["Fenix", "Focus", "GeckoView"]
 FIELDS = ["id", "summary", "flags", "severity",
           "priority", "status", "resolution"]
+
+BUGZILLA_QA_WHITEBOARD_FILTER = {
+    "cf_qa_whiteboard_type": "substring",
+    "cf_qa_whiteboard": "qa-found-in-"
+}
+
+BUGZILLA_BUGS_FIELDS = [
+    "id", "summary", "product",
+    "cf_qa_whiteboard", "severity",
+    "priority", "status", "resolution",
+    "creation_time", "last_change_time",
+    "whiteboard", "keywords", "cf_last_resolved"
+]

--- a/database.py
+++ b/database.py
@@ -85,6 +85,10 @@ class ReportBugzillaSoftvisionBugs(Base):
     __table__ = Table('report_bugzilla_softvision_bugs', Base.metadata, autoload=True) # noqa
 
 
+class ReportBugzillaSoftvisionBugsSync(Base):
+    __table__ = Table('report_bugzilla_softvision_bugs_sync', Base.metadata, autoload=True) # noqa
+
+
 class Database:
     def __init__(self):
         self.session = Session()


### PR DESCRIPTION
This PR adds funtionality to Bugzilla queries to update the existing entries for the bugs to have latest status instead of removing and creating the table.
It also adds a new data point `Average time-to-fix [net workdays]` by gathering the resolved_at date. In order to gather and later digest this data to create the graph, I had to add a new column to the table: `ReportBugzillaSoftvisionBugs` but instead of modifying it, I have create a temp one ReportBugzillaSoftvisionBugsSync where I am experimenting with the data. 
If everything looks good, I will modify the table to add this column permanently. 


