### PR TITLE
Update database_conn.py for SQLAlchemy 2.0+

### DIFF
--- a/lib/database_conn.py
+++ b/lib/database_conn.py
@@ -36,6 +36,7 @@ pool = create_engine(
         host=db_host,
         port=db_port,
         database=db_name,
+        query={}
     ),
     **db_config
 )


### PR DESCRIPTION
https://docs.sqlalchemy.org/en/20/core/engines.html#sqlalchemy.engine.URL.create

In 2.0+ they added a `query` parameter for the URL constructor.

> A dictionary of string keys to string values to be passed to the dialect and/or the DBAPI upon connect


```
URL.create(
    drivername="mysql+pymysql",
    username=db_username,
    password=db_password,
    host=db_host,
    port=db_port,
    database=db_name,
    query={}  # required in SQLAlchemy 2.0+
)
```
**Requires**: https://github.com/mozilla-mobile/testops-dashboard/pull/139