### PR TITLE
Fix Jira worklogs after API upgrade

### DIFF
--- a/api/jira/api_jira.py
+++ b/api/jira/api_jira.py
@@ -175,7 +175,7 @@ class JiraClient(Jira):
                     time_spent_seconds,
                     started_str,
                     comment,
-                    parent_name         # child_name placeholder
+                    parent_name
                 ])
 
             # ---- Get worklogs for each child ----

--- a/api/jira/api_jira.py
+++ b/api/jira/api_jira.py
@@ -33,6 +33,7 @@ from constants import (
     HOST_JIRA,
     MAX_RESULT,
     QATT_BOARD,
+    QATT_PARENT_TICKETS_IN_BOARD,
     SEARCH,
     STORY_POINTS,
     TESTED_TRAINS,
@@ -112,12 +113,10 @@ class Jira:
 
     # API: Issues
     def filter_child_issues(self, parent_key: str):
-        query = (
-            f"{SEARCH}"
-            f"?jql=filter={QATT_BOARD} AND parent={parent_key}"
-            f"&fields=summary&maxResults=100&expand=names"
-        )
-        return self.client.get_search(query, data_type="issues")
+        query = SEARCH + '?' + QATT_PARENT_TICKETS_IN_BOARD + parent_key
+        print("function: filter_child_issues")
+        print(f"DIAGNOSTIC - query: {query}")
+        return self.client.get_search(query, data_type='issues')
 
     # API: Worklogs
     def filter_worklogs(self, issue_key):
@@ -176,8 +175,7 @@ class JiraClient(Jira):
                     time_spent_seconds,
                     started_str,
                     comment,
-                    parent_name,
-                    None         # child_name placeholder
+                    parent_name         # child_name placeholder
                 ])
 
             # ---- Get worklogs for each child ----
@@ -230,7 +228,6 @@ class JiraClient(Jira):
             "time_spent", "time_seconds", "started_date",
             "comment", "parent_name", "child_name",
         ])
-
         self.db.jira_worklogs_delete()
         self.db.report_jira_sv_worklogs_insert(df)
 

--- a/lib/jira_conn.py
+++ b/lib/jira_conn.py
@@ -42,7 +42,7 @@ class JiraAPIClient:
         url = self.__url + query
         # Store all results
         all_results = []
-        params = {"startAt": 0, "maxResults": 100}  # Set pagination params
+        params = {"startAt": 0, "maxResults": 100, "fields": "key,summary"}
         headers = {"Content-Type": "application/json"}
 
         print(f"Fetching data from: {url}")


### PR DESCRIPTION
The worklogs for children tickets were not logged in. With these changes we iterate over them to get the worklogs for each one.
The problem was that we were using the id instead of the jira key. We also need to add the summary to the params so that the name of the child item appears.