### PR TITLE
Update Resource Data Insights YAML & Confluence API

### DIFF
--- a/api/confluence/api_confluence.py
+++ b/api/confluence/api_confluence.py
@@ -7,6 +7,7 @@ import os
 import glob
 import json
 import requests
+import sys
 import yaml
 
 from atlassian import Confluence
@@ -115,6 +116,7 @@ def page_payload_write(page_id, update_payload):
     else:
         print("Failed to update the page")
         print(update_response.text)
+        sys.exit(1)
 
 
 def page_payload(page_id, page_title, page_data, current_version, new_content):

--- a/config/confluence/yaml/data-insights-resource-data-insights.yaml
+++ b/config/confluence/yaml/data-insights-resource-data-insights.yaml
@@ -1,6 +1,6 @@
 wiki_page:
   page_id: "1346961433"
-  page_title: "Resource Data Insights"
+  page_title: "Resource Data Insights - Summary"
   sections:
     - name: "Mobile Feature Request Workload"
       reports:


### PR DESCRIPTION
Page: https://mozilla-hub.atlassian.net/wiki/spaces/MTE/pages/1346961433/Resource+Data+Insights+-+Summary

* Matches the `page_title`.
* Raises an `exit` on event that `Failed to update the page` is raised when updating pages. Previously these were silently failing, and you can only tell by looking at a successful log (e.g, [here](https://github.com/mozilla-mobile/testops-dashboard/actions/runs/17391535343/job/49366018276#step:7:2330))

Not sure if this fixes the problem in the screenshot (i.e, a title adjustment).

<img width="904" height="342" alt="Screenshot 2025-09-02 at 11 59 52 AM" src="https://github.com/user-attachments/assets/0471f029-eeef-4613-a99a-7732d3f5b191" />
