### PR TITLE
Jira API Upgrade - Fix pagination for all end points

### DIFF
--- a/lib/jira_conn.py
+++ b/lib/jira_conn.py
@@ -54,6 +54,12 @@ class JiraAPIClient:
 
         print(f"Fetching data from: {url}")
 
+        """
+        Pagination with Jira Cloud v3 Enhanced Search endpoint
+        /rest/api/3/search/jql → paginate with nextPageToken (isLast).
+        /rest/api/3/issue/{key}/worklog → paginate with startAt/maxResults/total
+        """
+
         if is_enhanced_search:
             # Enhanced JQL search: nextPageToken + isLast
             params = {"maxResults": 100}


### PR DESCRIPTION
Pagination is different in Jira API v3 depending on the end point. 

We need to do it differently for search and worklogs. 

- /rest/api/3/search/jql → paginate with nextPageToken (isLast).
- /rest/api/3/issue/{key}/worklog → paginate with startAt/maxResults/total