### PR TITLE
Fix KeyError in report_jira_qa_needed when fields_labels missing (atlassian-python-api 4.0.7)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,6 @@ idna
 requests
 urllib3
 python-bugzilla==3.3.0
-atlassian-python-api==4.0.4
+atlassian-python-api==4.0.7
 PyYAML
 Jinja2


### PR DESCRIPTION
The issue is that after upgrading to `atlassian-python-api` `4.0.7`, the Jira search payload no longer always includes `fields_labels`, causing a `KeyError` when normalizing the data in `report_jira_qa_needed`