### PR TITLE
Add: threaded Looker image generation

### DIFF
--- a/api/looker/api_looker.py
+++ b/api/looker/api_looker.py
@@ -8,6 +8,7 @@ import requests
 import time
 import re
 import os
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
 LOOKER_HOST = os.environ['LOOKER_HOST']
@@ -15,6 +16,7 @@ LOOKER_CLIENT_ID = os.environ['LOOKER_CLIENT_ID']
 LOOKER_SECRET = os.environ['LOOKER_SECRET']
 
 FOLDER_ID = 1820
+MAX_CONCURRENT_REQUESTS = 100
 
 project_root = Path.cwd()
 IMAGES_DIR = project_root / "config" / "confluence" / "images"
@@ -32,52 +34,43 @@ def get_looker_token():
 
 
 # Request a render task for the Look
-def create_render_task(access_token, look_id, image_format="png", width=400, height=400): # noqa
-    url = f"{LOOKER_HOST}/api/4.0/render_tasks/looks/{look_id}/{image_format}?width={width}&height={height}" # noqa
-    headers = {"Authorization": f"Bearer {access_token}"}
+def create_render_task(token, look_id, fmt="png", width=400, height=400):
+    url = (f"{LOOKER_HOST}/api/4.0/render_tasks/looks/"
+           f"{look_id}/{fmt}?width={width}&height={height}")
+    headers = {"Authorization": f"Bearer {token}"}
     payload = {"width": width, "height": height}
 
-    response = requests.post(url, headers=headers, json=payload)
-    response.raise_for_status()
-
-    return response.json()["id"]
-
-# Request a render task for the Dashboard
-def create_render_dashboard_task(access_token, dashboard_id, image_format="png", width=400, height=200): # noqa
-    url = f"{LOOKER_HOST}/api/4.0/render_tasks/dashboards/{dashboard_id}/{image_format}?width={width}&height={height}" # noqa
-    headers = {"Authorization": f"Bearer {access_token}"}
-    payload = {"width": width, "height": height}
-
-    response = requests.post(url, headers=headers, json=payload)
-    response.raise_for_status()
-
-    return response.json()["id"]
+    resp = requests.post(url, headers=headers, json=payload)
+    resp.raise_for_status()
+    return resp.json()["id"]
 
 
 # Poll until the render task is complete
-def wait_for_render_task(access_token, task_id, timeout=120):
-    # Waits for the Looker render task to complete, with a timeout.
+def wait_for_render_task(token, task_id, timeout=120):
+    """Waits for the Looker render task to complete, with a timeout."""
     url = f"{LOOKER_HOST}/api/4.0/render_tasks/{task_id}"
-    headers = {"Authorization": f"Bearer {access_token}"}
-    start_time = time.time()
+    headers = {"Authorization": f"Bearer {token}"}
+    start = time.time()
 
     while True:
-        response = requests.get(url, headers=headers)
-        response.raise_for_status()
-        task_status = response.json()
+        resp = requests.get(url, headers=headers)
+        resp.raise_for_status()
+        status = resp.json()
 
-        if task_status["status"] == "success":
-            return task_id  # Return the task_id to fetch the image
+        if status["status"] == "success":
+            return task_id
 
-        elif task_status["status"] in ["failure", "expired"]:
-            raise Exception(f"Render task failed or expired: {task_status}")
+        if status["status"] in ["failure", "expired"]:
+            raise Exception(f"Render task failed or expired: {status}")
 
-        elif task_status["status"] == "enqueued_for_render":
-            elapsed_time = time.time() - start_time
-            if elapsed_time > timeout:
-                raise Exception(f"Render task stuck in 'enqueued_for_render' for {timeout} seconds. Aborting.") # noqa
+        if status["status"] == "enqueued_for_render":
+            elapsed = time.time() - start
+            if elapsed > timeout:
+                raise Exception(
+                    f"Task stuck in 'enqueued_for_render' > {timeout}s. Aborting."
+                )
 
-        time.sleep(5)
+        time.sleep(2)
 
 
 # Download the rendered image and save it as a PNG file
@@ -114,17 +107,41 @@ def get_looks_in_folder(access_token, FOLDER_ID):
     return looks
 
 
+def process_single_look(access_token, look, images_dir):
+    """Process a single look: create task, wait for completion, download image"""
+    try:
+        print(f"Processing - ID: {look['id']}, Title: {look['title']}")
+        task_id = create_render_task(access_token, look['id'])
+        result_url = wait_for_render_task(access_token, task_id)
+        download_image(access_token, result_url, look['title'], images_dir)
+        return f"Successfully processed look {look['id']}: {look['title']}"
+    except Exception as e:
+        return f"Failed to process look {look['id']}: {look['title']} - Error: {str(e)}"
+
+
 def main():
     access_token = get_looker_token()
     # Ensure the directory exists, create if not
     os.makedirs(IMAGES_DIR, exist_ok=True)
 
     all_looks = get_looks_in_folder(access_token, FOLDER_ID)
-    for look in all_looks:
-        print(f"- ID: {look['id']}, Title: {look['title']}")
-        task_id = create_render_task(access_token, look['id'])
-        result_url = wait_for_render_task(access_token, task_id)
-        download_image(access_token, result_url, look['title'], IMAGES_DIR)
+
+    print(f"Found {len(all_looks)} looks to process")
+
+    with ThreadPoolExecutor(max_workers=MAX_CONCURRENT_REQUESTS) as executor:
+        # Submit all tasks
+        future_to_look = {
+            executor.submit(process_single_look, access_token, look, IMAGES_DIR): look
+            for look in all_looks
+        }
+
+        for future in as_completed(future_to_look):
+            look = future_to_look[future]
+            try:
+                result = future.result()
+                print(result)
+            except Exception as exc:
+                print(f'Look {look["id"]} generated an exception: {exc}')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* Adds threaded approach to Looker image generation to speed up the rendering and downloading

Takes now about ~1 minute on this manually ran action: https://github.com/mozilla-mobile/testops-dashboard/actions/runs/17649142703/job/50155149524 

Down from ~25 minutes https://github.com/mozilla-mobile/testops-dashboard/actions/runs/17632198299/job/50101536830