### PR TITLE
Fix testrail desktop tasks after testrail module refactor

### DIFF
--- a/api/testrail/report_test_plans_and_runs.py
+++ b/api/testrail/report_test_plans_and_runs.py
@@ -128,7 +128,7 @@ def testrail_runs_update(num_days, project_plans):
     for plan in project_plans.values():
         plan_info = tr.get_test_plan(plan['plan_id'], start_date)
         for entry in plan_info['entries']:
-            db.report_test_runs_insert(
+            report_test_runs_insert(
                 plan['id'], entry['suite_id'], entry['runs'])
 
 
@@ -170,3 +170,36 @@ def report_test_plans_insert(project_id, payload):
         db.session.commit()
         total['id'] = report.id
     return payload
+
+def report_test_runs_insert(db_plan_id, suite_id, runs):
+        db = _db()
+
+        for run in runs:
+            created_on = dt.convert_epoch_to_datetime(run['created_on'])
+            completed_on = (
+                dt.convert_epoch_to_datetime(run['completed_on'])
+                if run['completed_on'] else None
+            )
+            total_count = (
+                run['passed_count']
+                + run['retest_count']
+                + run['failed_count']
+                + run['blocked_count']
+            )
+
+            report_run = ReportTestRailTestRuns(
+                testrail_run_id=run['id'],
+                plan_id=db_plan_id,
+                suite_id=suite_id,
+                name=run['name'],
+                config=run['config'],
+                test_case_passed_count=run['passed_count'],
+                test_case_retest_count=run['retest_count'],
+                test_case_failed_count=run['failed_count'],
+                test_case_blocked_count=run['blocked_count'],
+                test_case_total_count=total_count,
+                testrail_created_on=created_on,
+                testrail_completed_on=completed_on)
+            db.session.add(report_run)
+            db.session.commit()
+

--- a/api/testrail/report_test_plans_and_runs.py
+++ b/api/testrail/report_test_plans_and_runs.py
@@ -119,7 +119,6 @@ def testrail_runs_update(num_days, project_plans):
     print(inspect.currentframe().f_code.co_name)
     print("--------------------------------------")
 
-    db = _db()
     tr = _tr()
 
     start_date = dt.start_date(num_days)
@@ -171,35 +170,34 @@ def report_test_plans_insert(project_id, payload):
         total['id'] = report.id
     return payload
 
+
 def report_test_runs_insert(db_plan_id, suite_id, runs):
-        db = _db()
+    db = _db()
 
-        for run in runs:
-            created_on = dt.convert_epoch_to_datetime(run['created_on'])
-            completed_on = (
-                dt.convert_epoch_to_datetime(run['completed_on'])
-                if run['completed_on'] else None
+    for run in runs:
+        created_on = dt.convert_epoch_to_datetime(run['created_on'])
+        completed_on = (
+            dt.convert_epoch_to_datetime(run['completed_on'])
+            if run['completed_on'] else None
             )
-            total_count = (
-                run['passed_count']
-                + run['retest_count']
-                + run['failed_count']
-                + run['blocked_count']
-            )
+        total_count = (
+            run['passed_count']
+            + run['retest_count']
+            + run['failed_count']
+            + run['blocked_count']
+        )
 
-            report_run = ReportTestRailTestRuns(
-                testrail_run_id=run['id'],
-                plan_id=db_plan_id,
-                suite_id=suite_id,
-                name=run['name'],
-                config=run['config'],
-                test_case_passed_count=run['passed_count'],
-                test_case_retest_count=run['retest_count'],
-                test_case_failed_count=run['failed_count'],
-                test_case_blocked_count=run['blocked_count'],
-                test_case_total_count=total_count,
-                testrail_created_on=created_on,
-                testrail_completed_on=completed_on)
-            db.session.add(report_run)
-            db.session.commit()
-
+        report_run = ReportTestRailTestRuns(
+            testrail_run_id=run['id'],
+            plan_id=db_plan_id,
+            suite_id=suite_id,
+            name=run['name'],
+            config=run['config'],
+            test_case_passed_count=run['passed_count'],
+            test_case_retest_count=run['retest_count'], # noqa               test_case_failed_count=run['failed_count'],
+            test_case_blocked_count=run['blocked_count'],
+            test_case_total_count=total_count,
+            testrail_created_on=created_on,
+            testrail_completed_on=completed_on)
+        db.session.add(report_run)
+        db.session.commit()

--- a/api/testrail/report_test_results.py
+++ b/api/testrail/report_test_results.py
@@ -171,7 +171,7 @@ def testrail_run_counts_update(project, num_days):
     print(totals)
 
     # Insert data in the 'totals' array into DB
-    db.report_test_runs_insert(projects_id, totals)
+    report_test_runs_insert(projects_id, totals)
 
 
 # ===================================================================
@@ -223,8 +223,8 @@ def report_testrail_test_result_insert(db_run_id, payload, type):
 
         report = ReportTestRailTestResults(**args)
 
-        #db.session.add(report)
-        #db.session.commit()
+        db.session.add(report)
+        db.session.commit()
         result['id'] = report.id
 
     return payload
@@ -256,5 +256,5 @@ def report_test_runs_insert(self, db_plan_id, suite_id, runs):
                 test_case_total_count=total_count,
                 testrail_created_on=created_on,
                 testrail_completed_on=completed_on)
-            #self.session.add(report_run)
-            #self.session.commit()
+            db.session.add(report_run)
+            db.session.commit()

--- a/api/testrail/report_test_results.py
+++ b/api/testrail/report_test_results.py
@@ -223,8 +223,38 @@ def report_testrail_test_result_insert(db_run_id, payload, type):
 
         report = ReportTestRailTestResults(**args)
 
-        db.session.add(report)
-        db.session.commit()
+        #db.session.add(report)
+        #db.session.commit()
         result['id'] = report.id
 
     return payload
+
+def report_test_runs_insert(self, db_plan_id, suite_id, runs):
+        for run in runs:
+            created_on = dt.convert_epoch_to_datetime(run['created_on'])
+            completed_on = (
+                dt.convert_epoch_to_datetime(run['completed_on'])
+                if run['completed_on'] else None
+            )
+            total_count = (
+                run['passed_count']
+                + run['retest_count']
+                + run['failed_count']
+                + run['blocked_count']
+            )
+
+            report_run = ReportTestRailTestRuns(
+                testrail_run_id=run['id'],
+                plan_id=db_plan_id,
+                suite_id=suite_id,
+                name=run['name'],
+                config=run['config'],
+                test_case_passed_count=run['passed_count'],
+                test_case_retest_count=run['retest_count'],
+                test_case_failed_count=run['failed_count'],
+                test_case_blocked_count=run['blocked_count'],
+                test_case_total_count=total_count,
+                testrail_created_on=created_on,
+                testrail_completed_on=completed_on)
+            #self.session.add(report_run)
+            #self.session.commit()

--- a/api/testrail/report_test_results.py
+++ b/api/testrail/report_test_results.py
@@ -229,32 +229,35 @@ def report_testrail_test_result_insert(db_run_id, payload, type):
 
     return payload
 
-def report_test_runs_insert(self, db_plan_id, suite_id, runs):
-        for run in runs:
-            created_on = dt.convert_epoch_to_datetime(run['created_on'])
-            completed_on = (
-                dt.convert_epoch_to_datetime(run['completed_on'])
-                if run['completed_on'] else None
-            )
-            total_count = (
-                run['passed_count']
-                + run['retest_count']
-                + run['failed_count']
-                + run['blocked_count']
-            )
 
-            report_run = ReportTestRailTestRuns(
-                testrail_run_id=run['id'],
-                plan_id=db_plan_id,
-                suite_id=suite_id,
-                name=run['name'],
-                config=run['config'],
-                test_case_passed_count=run['passed_count'],
-                test_case_retest_count=run['retest_count'],
-                test_case_failed_count=run['failed_count'],
-                test_case_blocked_count=run['blocked_count'],
-                test_case_total_count=total_count,
-                testrail_created_on=created_on,
-                testrail_completed_on=completed_on)
-            db.session.add(report_run)
-            db.session.commit()
+def report_test_runs_insert(self, db_plan_id, suite_id, runs):
+    db = _db()
+
+    for run in runs:
+        created_on = dt.convert_epoch_to_datetime(run['created_on'])
+        completed_on = (
+            dt.convert_epoch_to_datetime(run['completed_on'])
+            if run['completed_on'] else None
+        )
+        total_count = (
+            run['passed_count']
+            + run['retest_count']
+            + run['failed_count']
+            + run['blocked_count']
+        )
+
+        report_run = ReportTestRailTestRuns(
+            testrail_run_id=run['id'],
+            plan_id=db_plan_id,
+            suite_id=suite_id,
+            name=run['name'],
+            config=run['config'],
+            test_case_passed_count=run['passed_count'],
+            test_case_retest_count=run['retest_count'],
+            test_case_failed_count=run['failed_count'],
+            test_case_blocked_count=run['blocked_count'],
+            test_case_total_count=total_count,
+            testrail_created_on=created_on,
+            testrail_completed_on=completed_on)
+        db.session.add(report_run)
+        db.session.commit()


### PR DESCRIPTION
These tasks were failing:

- python ./__main__.py --platform desktop --project firefox-desktop --report-type testrail-test-plans-and-runs --num-days 30
- python ./__main__.py --report-type testrail-test-results --project firefox-desktop

With same error:
AttributeError: 'Database' object has no attribute 'report_test_runs_insert' 

