### PR TITLE
Bugfix MTE-4801 Add sentry_sentry_ios_project_id to env vars (production workflow)

### DIFF
--- a/.github/workflows/production-daily.yml
+++ b/.github/workflows/production-daily.yml
@@ -59,7 +59,7 @@ jobs:
             echo "SENTRY_HOST=${{ secrets.SENTRY_HOST }}" >> $GITHUB_ENV
             echo "SENTRY_API_TOKEN=${{ secrets.SENTRY_API_TOKEN_CSO }}" >> $GITHUB_ENV
             echo "SENTRY_ORGANIZATION_SLUG=${{ secrets.SENTRY_ORGANIZATION_SLUG }}" >> $GITHUB_ENV
-            echo "SENTRY_SENTRY_IOS_PROJECT_ID=${{ secrets.SENTRY_IOS_PROJECT_ID}}" >> $GITHUB_ENV
+            echo "SENTRY_IOS_PROJECT_ID=${{ secrets.SENTRY_IOS_PROJECT_ID}}" >> $GITHUB_ENV
 
       - name: Jira query
         run: python ./__main__.py --platform mobile --project ALL --report-type jira-qa-requests

--- a/.github/workflows/production-daily.yml
+++ b/.github/workflows/production-daily.yml
@@ -59,7 +59,7 @@ jobs:
             echo "SENTRY_HOST=${{ secrets.SENTRY_HOST }}" >> $GITHUB_ENV
             echo "SENTRY_API_TOKEN=${{ secrets.SENTRY_API_TOKEN_CSO }}" >> $GITHUB_ENV
             echo "SENTRY_ORGANIZATION_SLUG=${{ secrets.SENTRY_ORGANIZATION_SLUG }}" >> $GITHUB_ENV
-            echo "SENTRY_PROJECT_ID=${{ secrets.SENTRY_PROJECT_ID }}" >> $GITHUB_ENV
+            echo "SENTRY_SENTRY_IOS_PROJECT_ID=${{ secrets.SENTRY_IOS_PROJECT_ID}}" >> $GITHUB_ENV
 
       - name: Jira query
         run: python ./__main__.py --platform mobile --project ALL --report-type jira-qa-requests


### PR DESCRIPTION
The workflow failed in main because the env var has been renamed.
https://github.com/mozilla-mobile/testops-dashboard/actions/runs/18155621032/job/51674731221