### PR TITLE
Bugfix MTE-4801 Add fenix project ID to env vars

### DIFF
--- a/.github/workflows/production-daily.yml
+++ b/.github/workflows/production-daily.yml
@@ -60,6 +60,7 @@ jobs:
             echo "SENTRY_API_TOKEN=${{ secrets.SENTRY_API_TOKEN_CSO }}" >> $GITHUB_ENV
             echo "SENTRY_ORGANIZATION_SLUG=${{ secrets.SENTRY_ORGANIZATION_SLUG }}" >> $GITHUB_ENV
             echo "SENTRY_IOS_PROJECT_ID=${{ secrets.SENTRY_IOS_PROJECT_ID}}" >> $GITHUB_ENV
+            echo "SENTRY_FENIX_PROJECT_ID=${{ secrets.SENTRY_FENIX_PROJECT_ID}}" >> $GITHUB_ENV
 
       - name: Jira query
         run: python ./__main__.py --platform mobile --project ALL --report-type jira-qa-requests


### PR DESCRIPTION
The production workflow wasn't working because we need `SENTRY_FENIX_PROJECT_ID` to be defined for the new code.