### PR TITLE
MTE-4801 Fix json filename for Slack notification

### DIFF
--- a/.github/workflows/production-daily.yml
+++ b/.github/workflows/production-daily.yml
@@ -108,7 +108,7 @@ jobs:
         id: slack-sentry
         uses: slackapi/slack-github-action@v2.1.0
         with:
-          payload-file-path: "./sentry-slack.json"
+          payload-file-path: "./sentry-slack-firefox-ios.json"
           payload-templated: true 
           webhook:  ${{ secrets.SLACK_WEBHOOK_FIREFOX_IOS_DEV }}
           webhook-type: incoming-webhook


### PR DESCRIPTION
The daily production job failed because there's an update on the json filename, but I forgot to update the filename in the production workflow.

Here's the error:
https://github.com/mozilla-mobile/testops-dashboard/actions/runs/18216618196/job/51867147195