### PR TITLE
Add MTE-4930 Set crash free rate threshold of 99.5%

### DIFF
--- a/api/sentry/utils.py
+++ b/api/sentry/utils.py
@@ -18,6 +18,8 @@ def get_all_future_versions():
 def insert_rates(json_data, csv_file):
     all_future_versions = get_all_future_versions()
     print(all_future_versions)
+    LOW_CRASH_FREE_RATE_THRESHOLD = 99.5
+    flag_low_crash_free_rate_detected = False
     with open(csv_file, 'r') as file:
         rows = csv.DictReader(file)
         for row in rows:
@@ -39,6 +41,9 @@ def insert_rates(json_data, csv_file):
                 if all_future_versions is not None:
                     if release_version in all_future_versions:
                         release_version = release_version + " (Beta)"
+                if float(crash_free_rate_session) < LOW_CRASH_FREE_RATE_THRESHOLD or \
+                   float(crash_free_rate_user) < LOW_CRASH_FREE_RATE_THRESHOLD:
+                    flag_low_crash_free_rate_detected = True
                 json_data["blocks"].append(
                     {
                         "type": "section",
@@ -103,6 +108,18 @@ def insert_rates(json_data, csv_file):
                 ]
             }
         )
+        if flag_low_crash_free_rate_detected:
+            json_data["blocks"].append(
+                {
+                    "type": "context",
+                    "elements": [
+                        {
+                            "type": "mrkdwn",
+                            "text": "⚠️ Low crash-free rate(s) (<{0}%) detected ⚠️".format(LOW_CRASH_FREE_RATE_THRESHOLD)
+                        }
+                    ]
+                }
+            )
         json_data["blocks"].append(
             {
                 "type": "divider"


### PR DESCRIPTION
Would it be useful to add a warning ⚠️ to the Slack notification if low crash-free rates are detected? Just overhead this conversation among the developers on health monitoring:

<img width="432" height="574" alt="Screenshot 2025-10-07 at 16 35 52" src="https://github.com/user-attachments/assets/91c66881-12a4-4374-a1eb-dcb25248569a" />
<img width="426" height="171" alt="Screenshot 2025-10-07 at 16 35 41" src="https://github.com/user-attachments/assets/2a128bca-b89c-41c0-96a7-63761a820549" />
(See https://mozilla.slack.com/archives/C05C9RET70F/p1759852950579039)


We can have a notification with an extra line. Let me set the threshold to 99.5% so that the developers aren't pinged all the time. Since the rates have been hovering around 99.7%, 99.5% should indicate something bad is happening.
<img width="448" height="379" alt="Screenshot 2025-10-07 at 16 37 11" src="https://github.com/user-attachments/assets/5c35b2bd-c6d4-41bf-aad3-2401dc984138" />

