### PR TITLE
Bugfix MTE-4928 Add Fenix beta env var

### DIFF
--- a/.github/workflows/staging-daily.yml
+++ b/.github/workflows/staging-daily.yml
@@ -99,13 +99,11 @@ jobs:
         run: |
           python __main__.py --report-type sentry-issues --project firefox-ios
           python __main__.py --report-type sentry-rates --project firefox-ios
-        continue-on-error: true
 
       - name: Construct JSON for Slack (iOS)
         run: |
           python -m api.sentry.utils --file ./sentry_rates.csv --project firefox-ios
           ls sentry-slack-firefox-ios.json
-        continue-on-error: true
 
       - name: Send health notification to Slack (iOS)
         id: slack-sentry-ios
@@ -115,19 +113,16 @@ jobs:
           payload-templated: true 
           webhook:  ${{ secrets.SLACK_WEBHOOK_URL_TEST_ALERTS_SANDBOX }}
           webhook-type: incoming-webhook
-        continue-on-error: true
 
       - name: Sentry query (Android)
         run: |
           python __main__.py --report-type sentry-issues --project fenix
           python __main__.py --report-type sentry-rates --project fenix
-        continue-on-error: true
 
       - name: Construct JSON for Slack (Android)
         run: |
           python -m api.sentry.utils --file ./sentry_rates.csv --project fenix
           ls sentry-slack-fenix.json
-        continue-on-error: true
 
       - name: Send health notification to Slack (Android)
         id: slack-sentry-fenix
@@ -137,18 +132,15 @@ jobs:
           payload-templated: true 
           webhook:  ${{ secrets.SLACK_WEBHOOK_PRODUCT_HEALTH }}
           webhook-type: incoming-webhook
-        continue-on-error: true
 
       - name: Sentry query (Android Beta)
         run: |
           python __main__.py --report-type sentry-issues --project fenix-beta
           python __main__.py --report-type sentry-rates --project fenix-beta
-        continue-on-error: true
       - name: Construct JSON for Slack (Android Beta)
         run: |
           python -m api.sentry.utils --file ./sentry_rates.csv --project fenix-beta
           ls sentry-slack-fenix-beta.json
-        continue-on-error: true
       - name: Send health notification to Slack (Android Beta)
         id: slack-sentry-fenix-beta
         uses: slackapi/slack-github-action@v2.1.0
@@ -157,4 +149,3 @@ jobs:
           payload-templated: true
           webhook:  ${{ secrets.SLACK_WEBHOOK_PRODUCT_HEALTH }}
           webhook-type: incoming-webhook
-        continue-on-error: true


### PR DESCRIPTION
The notifications weren't sent to the `#mobile-alerts-product-health` Slack channel because environment variable `SENTRY_FENIX_BETA_PROJECT_ID` has been missing from the Github Actions workflow. The workflow failed.

I have run the job "Mobile Testops Report DAILY - Staging" on the branch. Here's the notification:
<img width="300" alt="Screenshot 2025-10-21 at 14 40 15" src="https://github.com/user-attachments/assets/d0f504d8-833b-4bef-b766-f51978acf995" />
