### PR TITLE
Refactor "Testops Report DAILY - Production Github Actions" to run in parallel

### DIFF
--- a/.github/workflows/production-daily.yml
+++ b/.github/workflows/production-daily.yml
@@ -12,7 +12,7 @@ on:
         default: 'master'
 
 env:
-  CLOUD_SQL_DATABASE_NAME: preflight
+  CLOUD_SQL_DATABASE_NAME: production
   CLOUD_SQL_DATABASE_USERNAME: ${{ secrets.CLOUD_SQL_DATABASE_USERNAME }}
   CLOUD_SQL_DATABASE_PASSWORD: ${{ secrets.CLOUD_SQL_DATABASE_PASSWORD }}
   CLOUD_SQL_DATABASE_PORT: ${{ secrets.CLOUD_SQL_DATABASE_PORT }}
@@ -112,7 +112,7 @@ jobs:
         with:
           payload-file-path: "./sentry-slack-firefox-ios.json"
           payload-templated: true 
-          webhook:  ${{ secrets.SLACK_WEBHOOK_URL_TEST_ALERTS_SANDBOX }}
+          webhook:  ${{ secrets.SLACK_WEBHOOK_FIREFOX_IOS_DEV }}
           webhook-type: incoming-webhook
         continue-on-error: true
 
@@ -134,7 +134,7 @@ jobs:
           JOB_STATUS: ${{ (needs.reports.result == 'success' && needs.sentry.result == 'success') && ':white_check_mark:' || ':x:' }}
           JOB_STATUS_COLOR: ${{ (needs.reports.result == 'success' && needs.sentry.result == 'success') && '#36a64f' || '#FF0000' }}
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL_TEST_ALERTS_SANDBOX }}
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL_MOBILE_ALERTS_TOOLING }}
           webhook-type: webhook-trigger
           payload-templated: true
           payload-file-path: "./config/payload-slack-content.json"


### PR DESCRIPTION
I am trying to parallelize the production Github Actions. There should be *NO* changes in the existing functionalities.

For testing I have been using `preflight` database and the `#mobile-alerts-sandbox` Slack channel.

When it's time for adding more Sentry queries to production, the file diff would be readable.

Sample test run: https://github.com/mozilla-mobile/testops-dashboard/actions/runs/18729374912

🤖 Prompt to Claude Sonnet 4: `could you please rewrite production-daily.yml in the same fashion as staging-daily? in staging-daily, we run the queries in parallel.`