### PR TITLE
Apple and Android icons for testops notifications?

### DIFF
--- a/api/sentry/utils.py
+++ b/api/sentry/utils.py
@@ -55,7 +55,7 @@ def insert_rates(json_data, csv_file, project):
                         "text": {
                             "type": "mrkdwn",
                             "text": (
-                                "*v{0}* → :iphone: {1}%  "
+                                "*v{0}* :iphone: {1}%  "
                                 ":bust_in_silhouette: {2}% "
                                 ":rocket: {3}%"
                             ).format(
@@ -164,11 +164,11 @@ def insert_json_content(json_data, versions):
 def init_json(project):
     now = DatetimeUtils.start_date('0')
     project_config = {
-        "firefox-ios": ":apple: iOS",
-        "fenix": ":android: Android",
-        "fenix-beta": ":android: Android (Beta)"
+        "firefox-ios": ":testops-apple: iOS",
+        "fenix": ":testops-android: Android",
+        "fenix-beta": ":testops-android: Android (Beta)"
     }
-    platform = project_config.get(project, ":android: Android")
+    platform = project_config.get(project, ":testops-android: Android")
     json_data = {
         "blocks": [
             {


### PR DESCRIPTION
I would like to suggest the following icons to denote iOS and Android respectively:
<img width="40" height="1000" alt="580b57fcd9996e24bc43c516" src="https://github.com/user-attachments/assets/6392987a-536b-440b-af86-3a9895fbb861" />
<img width="40" height="1166" alt="android-robot-head-2023-seeklogo" src="https://github.com/user-attachments/assets/44995edd-9352-4823-80ac-781e9f52ee12" />
These icons are bright. Their size extends to the maximum height or width when possible. The Android icon is the up-to-date one in use since 2023. Those icons are added to Mozilla's slack with the names `:testops-apple:` and `:testops-android:` respectively.

In addition, let's remove `→` from each of the versions. The report is understood without the character. We may save some lengths for smaller devices such as a phone.

The notifications would look like the following. What do you all think?
<img width="400" height="358" alt="Screenshot 2025-10-24 at 00 40 27" src="https://github.com/user-attachments/assets/bd7652ec-5c0b-489e-bf1c-4dda735fd9c0" />
<img width="400" height="319" alt="Screenshot 2025-10-24 at 00 40 36" src="https://github.com/user-attachments/assets/c18bc16c-1acb-493e-ba50-efd712e621af" />
