### PR TITLE
Fix URL for iOS looker report

### DIFF
--- a/api/sentry/utils.py
+++ b/api/sentry/utils.py
@@ -11,7 +11,7 @@ project_config = {
     "firefox-ios": {
         "title": ":testops-apple: iOS",
         "looker_dashboard_url": (
-            "https://mozilla.cloud.looker.com/dashboards/2380"
+            "https://mozilla.cloud.looker.com/dashboards/2381"
         ),
         "confluence_report_url": (
             "https://mozilla-hub.atlassian.net/wiki/spaces/"


### PR DESCRIPTION
I had a typo in the URL during the last refactor. The URL should be https://mozilla.cloud.looker.com/dashboards/2381 (not `2380`).