### PR TITLE
Add MTE-4802 Add Looker and Confluence links to Android Health Report Slack Notifications

### DIFF
--- a/api/sentry/utils.py
+++ b/api/sentry/utils.py
@@ -19,7 +19,14 @@ project_config = {
         )
     },
     "fenix": {
-        "title": ":testops-android: Android"
+        "title": ":testops-android: Android",
+        "looker_dashboard_url": (
+            "https://mozilla.cloud.looker.com/dashboards/2643"
+        ),
+        "confluence_report_url": (
+            "https://mozilla-hub.atlassian.net/wiki/spaces/"
+            "MTE/pages/1695154291/Android+Health+Monitor+Report"
+        )
     },
     "fenix-beta": {
         "title": ":testops-android: Android (Beta)"


### PR DESCRIPTION
This PR enables the Android health report to contain the buttons to the Looker and Confluence reports:

* https://mozilla.cloud.looker.com/dashboards/2643 (I will fill in the graphs.)
* https://mozilla-hub.atlassian.net/wiki/spaces/MTE/pages/1695154291/Android+Health+Monitor+Report