### PR TITLE
Update Looker graph URL for Mobile Incidents report

### DIFF
--- a/config/confluence/yaml/team-delivery-insights-2025-h1.yaml
+++ b/config/confluence/yaml/team-delivery-insights-2025-h1.yaml
@@ -43,7 +43,7 @@ wiki_page:
         - report-title: "Mobile Incidents Severity - 2025"
           report-description: "Incidents by Severity - 2025"
           attachment-filename: "mobile-incidents-severity-2025.png"
-          looker-graph-url: "https://mozilla.cloud.looker.com/looks/2867"
+          looker-graph-url: "https://mozilla.cloud.looker.com/looks/2965"
 
         - report-title: "Mobile Incidents by Month - 2025"
           report-description: "Mobile Incidents by Month - 2025"


### PR DESCRIPTION
* Fix URL to: https://mozilla.cloud.looker.com/looks/2965