### PR TITLE
Fix github ations for Desktop tasks missing arguments

### DIFF
--- a/.github/workflows/production-daily-desktop.yaml
+++ b/.github/workflows/production-daily-desktop.yaml
@@ -66,5 +66,26 @@ jobs:
         continue-on-error: true
 
       - name: Query Bugzilla Softvision Bugs
-        run: python ./__main__.py --platform desktop --report-type bugzilla-desktop-bugs
- 
+        run: python ./__main__.py --platform desktop --project firefox-desktop --report-type bugzilla-desktop-bugs
+
+      - name: Set job log URL
+        if: always()
+        run: echo "JOB_LOG_URL=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> $GITHUB_ENV
+
+      - name: Send custom JSON data to Slack workflow
+        if: always()
+        id: slack
+        uses: slackapi/slack-github-action@v2.1.1
+        env:
+          WORKFLOW_NAME: ${{ github.workflow }}
+          BRANCH: ${{ github.head_ref || github.ref_name }}
+          JOB_STATUS: ${{ job.status == 'success' && ':white_check_mark:' || job.status == 'failure' && ':x:' }}
+          JOB_STATUS_COLOR: ${{ job.status == 'success' && '#36a64f' || job.status == 'failure' && '#FF0000' }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_MOBILE_ALERTS_TOOLING }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL_MOBILE_ALERTS_TOOLING }}
+          webhook-type: webhook-trigger
+          payload-templated: true
+          payload-file-path: "./config/payload-slack-content.json"

--- a/.github/workflows/production-weekly-desktop.yaml
+++ b/.github/workflows/production-weekly-desktop.yaml
@@ -52,16 +52,17 @@ jobs:
         continue-on-error: true
 
       - name: Query Bugzilla Release Flags Bugs
-        run: python ./__main__.py --report-type bugzilla-desktop-release-flags-for-bugs
+        run: python ./__main__.py --platform desktop --project firefox-desktop --report-type bugzilla-desktop-release-flags-for-bugs
         continue-on-error: true
 
       - name: Query Bugzilla Overall Bugs
-        run: python ./__main__.py --report-type bugzilla-desktop-overall-bugs
+        run: python ./__main__.py --platform desktop --project firefox-desktop --report-type bugzilla-desktop-overall-bugs
         continue-on-error: true
 
       - name: Set job log URL
         if: always()
         run: echo "JOB_LOG_URL=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> $GITHUB_ENV
+
       - name: Send custom JSON data to Slack workflow
         if: always()
         id: slack

--- a/.github/workflows/production-weekly.yml
+++ b/.github/workflows/production-weekly.yml
@@ -60,6 +60,7 @@ jobs:
       - name: Set job log URL
         if: always()
         run: echo "JOB_LOG_URL=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> $GITHUB_ENV
+
       - name: Send custom JSON data to Slack workflow
         if: always()
         id: slack

--- a/.github/workflows/staging-weekly-desktop.yml
+++ b/.github/workflows/staging-weekly-desktop.yml
@@ -41,6 +41,7 @@ jobs:
             echo "ATLASSIAN_API_TOKEN=${{ secrets.ATLASSIAN_API_TOKEN }}" >> $GITHUB_ENV
             echo "ATLASSIAN_HOST=${{ secrets.ATLASSIAN_HOST }}" >> $GITHUB_ENV
             echo "ATLASSIAN_USERNAME=${{ secrets.ATLASSIAN_USERNAME }}" >> $GITHUB_ENV
+            echo "BUGZILLA_API_KEY=${{ secrets.BUGZILLA_API_KEY }}" >> $GITHUB_ENV
 
       - name: Query Test Plans and Runs
         run: python ./__main__.py --report-type testrail-test-results --project firefox-desktop
@@ -52,3 +53,25 @@ jobs:
 
       - name: Query Bugzilla Overall Bugs
         run: python ./__main__.py --report-type bugzilla-desktop-overall-bugs
+
+      - name: Set job log URL
+        if: always()
+        run: echo "JOB_LOG_URL=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> $GITHUB_ENV
+
+      - name: Send custom JSON data to Slack workflow
+        if: always()
+        id: slack
+        uses: slackapi/slack-github-action@v2.1.1
+        env:
+          WORKFLOW_NAME: ${{ github.workflow }}
+          BRANCH: ${{ github.head_ref || github.ref_name }}
+          JOB_STATUS: ${{ job.status == 'success' && ':white_check_mark:' || job.status == 'failure' && ':x:' }}
+          JOB_STATUS_COLOR: ${{ job.status == 'success' && '#36a64f' || job.status == 'failure' && '#FF0000' }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_MOBILE_ALERTS_TOOLING }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL_MOBILE_ALERTS_TOOLING }}
+          webhook-type: webhook-trigger
+          payload-templated: true
+          payload-file-path: "./config/payload-slack-content.json"


### PR DESCRIPTION
I realized that the github action is failing:
https://github.com/mozilla-mobile/testops-dashboard/actions/runs/19489489723/job/55778787556
missing the project argument. Then I also noticed that these jobs did not have the slack notification and added it.