### PR TITLE
MTE-5242 Refactor in sentry and github utils

### DIFF
--- a/.github/workflows/production-weekly-firefox-ios-deepdive.yaml
+++ b/.github/workflows/production-weekly-firefox-ios-deepdive.yaml
@@ -74,7 +74,7 @@ jobs:
           method: chat.postMessage
           token: ${{ secrets.SLACK_TESTOPS_BOT_TOKEN }}
           payload: |
-            channel: "${{ secrets.SLACK_CHANNEL_ID_MOBILE_ALERTS_SANDBOX  }}"
+            channel: "${{ secrets.SLACK_CHANNEL_ID_FIREFOX_IOS_DEV  }}"
             text: ":health: Health Monitoring Deep Dive - (${{ steps.date.outputs.value }})"
             blocks:
               - type: section
@@ -83,11 +83,11 @@ jobs:
                   text: ":health: *Health Monitoring Deep Dive (${{ steps.date.outputs.value }})* :thread:"
       - name: Create Slack payloads
         run: |
-          jq --arg channel "${{ secrets.SLACK_CHANNEL_ID_MOBILE_ALERTS_SANDBOX  }}" \
+          jq --arg channel "${{ secrets.SLACK_CHANNEL_ID_FIREFOX_IOS_DEV  }}" \
              --arg thread_ts "${{ steps.slack-health.outputs.ts }}" \
              '. + {channel: $channel, thread_ts: $thread_ts}' \
              sentry-slack-firefox-ios.json > sentry-slack-firefox-ios-thread.json
-          jq --arg channel "${{ secrets.SLACK_CHANNEL_ID_MOBILE_ALERTS_SANDBOX  }}" \
+          jq --arg channel "${{ secrets.SLACK_CHANNEL_ID_FIREFOX_IOS_DEV  }}" \
              --arg thread_ts "${{ steps.slack-health.outputs.ts }}" \
              '. + {channel: $channel, thread_ts: $thread_ts}' \
              github-new-issues-slack.json > github-new-issues-slack-thread.json
@@ -97,7 +97,7 @@ jobs:
           method: chat.postMessage
           token: ${{ secrets.SLACK_TESTOPS_BOT_TOKEN }}
           payload: |
-            channel: "${{ secrets.SLACK_CHANNEL_ID_MOBILE_ALERTS_SANDBOX }}"
+            channel: "${{ secrets.SLACK_CHANNEL_ID_FIREFOX_IOS_DEV }}"
             thread_ts: "${{ steps.slack-health.outputs.ts }}"
             text: ":looker: <https://mozilla.cloud.looker.com/dashboards/operational_monitoring::firefox_ios_health?Date=&Percentile=50|Looker Dashboard>"
       - name: "Post to Slack: Crash Free Rates"

--- a/.github/workflows/production-weekly-firefox-ios-deepdive.yaml
+++ b/.github/workflows/production-weekly-firefox-ios-deepdive.yaml
@@ -13,7 +13,7 @@ on:
         default: 'master'
 
 env:
-  CLOUD_SQL_DATABASE_NAME: preflight
+  CLOUD_SQL_DATABASE_NAME: production
   CLOUD_SQL_DATABASE_USERNAME: ${{ secrets.CLOUD_SQL_DATABASE_USERNAME }}
   CLOUD_SQL_DATABASE_PASSWORD: ${{ secrets.CLOUD_SQL_DATABASE_PASSWORD }}
   CLOUD_SQL_DATABASE_PORT: ${{ secrets.CLOUD_SQL_DATABASE_PORT }}
@@ -74,7 +74,7 @@ jobs:
           method: chat.postMessage
           token: ${{ secrets.SLACK_TESTOPS_BOT_TOKEN }}
           payload: |
-            channel: "${{ secrets.SLACK_CHANNEL_ID_MOBILE_ALERTS_SANDBOX }}"
+            channel: "${{ secrets.SLACK_CHANNEL_ID_FIREFOX_IOS_DEV }}"
             text: ":health: Health Monitoring Deep Dive - (${{ steps.date.outputs.value }})"
             blocks:
               - type: section
@@ -83,11 +83,11 @@ jobs:
                   text: ":health: *Health Monitoring Deep Dive (${{ steps.date.outputs.value }})* :thread:"
       - name: Create Slack payloads
         run: |
-          jq --arg channel "${{ secrets.SLACK_CHANNEL_ID_MOBILE_ALERTS_SANDBOX }}" \
+          jq --arg channel "${{ secrets.SLACK_CHANNEL_ID_FIREFOX_IOS_DEV }}" \
              --arg thread_ts "${{ steps.slack-health.outputs.ts }}" \
              '. + {channel: $channel, thread_ts: $thread_ts}' \
              sentry-slack-firefox-ios.json > sentry-slack-firefox-ios-thread.json
-          jq --arg channel "${{ secrets.SLACK_CHANNEL_ID_MOBILE_ALERTS_SANDBOX }}" \
+          jq --arg channel "${{ secrets.SLACK_CHANNEL_ID_FIREFOX_IOS_DEV }}" \
              --arg thread_ts "${{ steps.slack-health.outputs.ts }}" \
              '. + {channel: $channel, thread_ts: $thread_ts}' \
              github-new-issues-slack.json > github-new-issues-slack-thread.json
@@ -97,7 +97,7 @@ jobs:
           method: chat.postMessage
           token: ${{ secrets.SLACK_TESTOPS_BOT_TOKEN }}
           payload: |
-            channel: "${{ secrets.SLACK_CHANNEL_ID_MOBILE_ALERTS_SANDBOX }}"
+            channel: "${{ secrets.SLACK_CHANNEL_ID_FIREFOX_IOS_DEV }}"
             thread_ts: "${{ steps.slack-health.outputs.ts }}"
             text: ":looker: <https://mozilla.cloud.looker.com/dashboards/operational_monitoring::firefox_ios_health?Date=&Percentile=50|Looker Dashboard>"
       - name: "Post to Slack: Crash Free Rates"

--- a/.github/workflows/production-weekly-firefox-ios-deepdive.yaml
+++ b/.github/workflows/production-weekly-firefox-ios-deepdive.yaml
@@ -13,7 +13,7 @@ on:
         default: 'master'
 
 env:
-  CLOUD_SQL_DATABASE_NAME: production
+  CLOUD_SQL_DATABASE_NAME: preflight
   CLOUD_SQL_DATABASE_USERNAME: ${{ secrets.CLOUD_SQL_DATABASE_USERNAME }}
   CLOUD_SQL_DATABASE_PASSWORD: ${{ secrets.CLOUD_SQL_DATABASE_PASSWORD }}
   CLOUD_SQL_DATABASE_PORT: ${{ secrets.CLOUD_SQL_DATABASE_PORT }}
@@ -74,7 +74,7 @@ jobs:
           method: chat.postMessage
           token: ${{ secrets.SLACK_TESTOPS_BOT_TOKEN }}
           payload: |
-            channel: "${{ secrets.SLACK_CHANNEL_ID_FIREFOX_IOS_DEV }}"
+            channel: "${{ secrets.SLACK_CHANNEL_ID_MOBILE_ALERTS_SANDBOX }}"
             text: ":health: Health Monitoring Deep Dive - (${{ steps.date.outputs.value }})"
             blocks:
               - type: section
@@ -83,11 +83,11 @@ jobs:
                   text: ":health: *Health Monitoring Deep Dive (${{ steps.date.outputs.value }})* :thread:"
       - name: Create Slack payloads
         run: |
-          jq --arg channel "${{ secrets.SLACK_CHANNEL_ID_FIREFOX_IOS_DEV }}" \
+          jq --arg channel "${{ secrets.SLACK_CHANNEL_ID_MOBILE_ALERTS_SANDBOX }}" \
              --arg thread_ts "${{ steps.slack-health.outputs.ts }}" \
              '. + {channel: $channel, thread_ts: $thread_ts}' \
              sentry-slack-firefox-ios.json > sentry-slack-firefox-ios-thread.json
-          jq --arg channel "${{ secrets.SLACK_CHANNEL_ID_FIREFOX_IOS_DEV }}" \
+          jq --arg channel "${{ secrets.SLACK_CHANNEL_ID_MOBILE_ALERTS_SANDBOX }}" \
              --arg thread_ts "${{ steps.slack-health.outputs.ts }}" \
              '. + {channel: $channel, thread_ts: $thread_ts}' \
              github-new-issues-slack.json > github-new-issues-slack-thread.json
@@ -97,7 +97,7 @@ jobs:
           method: chat.postMessage
           token: ${{ secrets.SLACK_TESTOPS_BOT_TOKEN }}
           payload: |
-            channel: "${{ secrets.SLACK_CHANNEL_ID_FIREFOX_IOS_DEV }}"
+            channel: "${{ secrets.SLACK_CHANNEL_ID_MOBILE_ALERTS_SANDBOX }}"
             thread_ts: "${{ steps.slack-health.outputs.ts }}"
             text: ":looker: <https://mozilla.cloud.looker.com/dashboards/operational_monitoring::firefox_ios_health?Date=&Percentile=50|Looker Dashboard>"
       - name: "Post to Slack: Crash Free Rates"

--- a/.github/workflows/production-weekly-firefox-ios-deepdive.yaml
+++ b/.github/workflows/production-weekly-firefox-ios-deepdive.yaml
@@ -13,7 +13,7 @@ on:
         default: 'master'
 
 env:
-  CLOUD_SQL_DATABASE_NAME: preflight
+  CLOUD_SQL_DATABASE_NAME: production
   CLOUD_SQL_DATABASE_USERNAME: ${{ secrets.CLOUD_SQL_DATABASE_USERNAME }}
   CLOUD_SQL_DATABASE_PASSWORD: ${{ secrets.CLOUD_SQL_DATABASE_PASSWORD }}
   CLOUD_SQL_DATABASE_PORT: ${{ secrets.CLOUD_SQL_DATABASE_PORT }}
@@ -74,7 +74,7 @@ jobs:
           method: chat.postMessage
           token: ${{ secrets.SLACK_TESTOPS_BOT_TOKEN }}
           payload: |
-            channel: "${{ secrets.SLACK_CHANNEL_ID_FIREFOX_IOS_DEV  }}"
+            channel: "${{ secrets.SLACK_CHANNEL_ID_FIREFOX_IOS_DEV }}"
             text: ":health: Health Monitoring Deep Dive - (${{ steps.date.outputs.value }})"
             blocks:
               - type: section
@@ -83,11 +83,11 @@ jobs:
                   text: ":health: *Health Monitoring Deep Dive (${{ steps.date.outputs.value }})* :thread:"
       - name: Create Slack payloads
         run: |
-          jq --arg channel "${{ secrets.SLACK_CHANNEL_ID_FIREFOX_IOS_DEV  }}" \
+          jq --arg channel "${{ secrets.SLACK_CHANNEL_ID_FIREFOX_IOS_DEV }}" \
              --arg thread_ts "${{ steps.slack-health.outputs.ts }}" \
              '. + {channel: $channel, thread_ts: $thread_ts}' \
              sentry-slack-firefox-ios.json > sentry-slack-firefox-ios-thread.json
-          jq --arg channel "${{ secrets.SLACK_CHANNEL_ID_FIREFOX_IOS_DEV  }}" \
+          jq --arg channel "${{ secrets.SLACK_CHANNEL_ID_FIREFOX_IOS_DEV }}" \
              --arg thread_ts "${{ steps.slack-health.outputs.ts }}" \
              '. + {channel: $channel, thread_ts: $thread_ts}' \
              github-new-issues-slack.json > github-new-issues-slack-thread.json

--- a/.github/workflows/production-weekly-firefox-ios-deepdive.yaml
+++ b/.github/workflows/production-weekly-firefox-ios-deepdive.yaml
@@ -74,7 +74,7 @@ jobs:
           method: chat.postMessage
           token: ${{ secrets.SLACK_TESTOPS_BOT_TOKEN }}
           payload: |
-            channel: "${{ secrets.SLACK_CHANNEL_ID_FIREFOX_IOS_DEV }}"
+            channel: "${{ secrets.SLACK_CHANNEL_ID_MOBILE_ALERTS_SANDBOX  }}"
             text: ":health: Health Monitoring Deep Dive - (${{ steps.date.outputs.value }})"
             blocks:
               - type: section
@@ -83,11 +83,11 @@ jobs:
                   text: ":health: *Health Monitoring Deep Dive (${{ steps.date.outputs.value }})* :thread:"
       - name: Create Slack payloads
         run: |
-          jq --arg channel "${{ secrets.SLACK_CHANNEL_ID_FIREFOX_IOS_DEV }}" \
+          jq --arg channel "${{ secrets.SLACK_CHANNEL_ID_MOBILE_ALERTS_SANDBOX  }}" \
              --arg thread_ts "${{ steps.slack-health.outputs.ts }}" \
              '. + {channel: $channel, thread_ts: $thread_ts}' \
              sentry-slack-firefox-ios.json > sentry-slack-firefox-ios-thread.json
-          jq --arg channel "${{ secrets.SLACK_CHANNEL_ID_FIREFOX_IOS_DEV }}" \
+          jq --arg channel "${{ secrets.SLACK_CHANNEL_ID_MOBILE_ALERTS_SANDBOX  }}" \
              --arg thread_ts "${{ steps.slack-health.outputs.ts }}" \
              '. + {channel: $channel, thread_ts: $thread_ts}' \
              github-new-issues-slack.json > github-new-issues-slack-thread.json

--- a/.github/workflows/production-weekly-firefox-ios-deepdive.yaml
+++ b/.github/workflows/production-weekly-firefox-ios-deepdive.yaml
@@ -13,7 +13,7 @@ on:
         default: 'master'
 
 env:
-  CLOUD_SQL_DATABASE_NAME: production
+  CLOUD_SQL_DATABASE_NAME: preflight
   CLOUD_SQL_DATABASE_USERNAME: ${{ secrets.CLOUD_SQL_DATABASE_USERNAME }}
   CLOUD_SQL_DATABASE_PASSWORD: ${{ secrets.CLOUD_SQL_DATABASE_PASSWORD }}
   CLOUD_SQL_DATABASE_PORT: ${{ secrets.CLOUD_SQL_DATABASE_PORT }}
@@ -97,7 +97,7 @@ jobs:
           method: chat.postMessage
           token: ${{ secrets.SLACK_TESTOPS_BOT_TOKEN }}
           payload: |
-            channel: "${{ secrets.SLACK_CHANNEL_ID_FIREFOX_IOS_DEV }}"
+            channel: "${{ secrets.SLACK_CHANNEL_ID_MOBILE_ALERTS_SANDBOX }}"
             thread_ts: "${{ steps.slack-health.outputs.ts }}"
             text: ":looker: <https://mozilla.cloud.looker.com/dashboards/operational_monitoring::firefox_ios_health?Date=&Percentile=50|Looker Dashboard>"
       - name: "Post to Slack: Crash Free Rates"

--- a/api/github/utils.py
+++ b/api/github/utils.py
@@ -1,6 +1,7 @@
 import csv
 import sys
 import json
+from urllib.parse import urlencode
 
 
 def main():
@@ -49,10 +50,9 @@ def csv_to_slack_message(csv_filename):
 
 
 def create_slack_json_message(issues: list) -> dict:
-    GITHUB_URL = (
-        "https://github.com/mozilla-mobile/firefox-ios/issues?"
-        "q=is%3Aopen%20is%3Aissue%20no%3Aassignee%20-author%3Adata-sync-user"
-    )
+    GITHUB_REPO = "mozilla-mobile/firefox-ios"
+    query_params = {"q": "is:open is:issue no:assignee -author:data-sync-user"}
+    GITHUB_URL = f"https://github.com/{GITHUB_REPO}/issues?{urlencode(query_params)}"
     if not issues:
         return {
             "blocks": [

--- a/api/sentry/utils.py
+++ b/api/sentry/utils.py
@@ -3,6 +3,7 @@ import csv
 import argparse
 import tomllib
 from pathlib import Path
+from urllib.parse import urlencode
 import requests
 import yaml
 
@@ -11,6 +12,12 @@ from utils.datetime_utils import DatetimeUtils
 
 with open('config/sentry/projects.toml', 'rb') as f:
     project_config = tomllib.load(f)
+
+
+def build_url(base_url: str, params: dict | None = None) -> str:
+    if not params:
+        return base_url
+    return f"{base_url}?{urlencode(params)}"
 
 
 def get_all_future_versions():
@@ -30,10 +37,12 @@ def insert_rates(json_data, csv_file, project, shortform=False):
         low_crash_free_rate_threshold = rules.get(project).get(
             'LOW_CRASH_FREE_RATE_THRESHOLD', 99.5)
     flag_low_crash_free_rate_detected = False
-    looker_dashboard_url = project_config.get(project).get(
-        'looker_dashboard_url', None)
-    confluence_report_url = project_config.get(project).get(
-        'confluence_report_url', None)
+    looker_config = project_config.get(project, {}).get('looker', {})
+    looker_dashboard_url = build_url(
+        looker_config['base_url'], looker_config.get('params')
+    ) if looker_config else None
+    confluence_report_url = project_config.get(project, {}).get(
+        'confluence', {}).get('url', None)
     is_low_adoption = False
     with open(csv_file, 'r') as file:
         rows = csv.DictReader(file)
@@ -235,7 +244,10 @@ def insert_json_footer(json_data):
 
 def init_json(project, shortform=False):
     if shortform:
-        sentry_url = project_config.get(project).get('sentry_url')
+        sentry_config = project_config.get(project, {}).get('sentry', {})
+        sentry_url = build_url(
+            sentry_config['base_url'], sentry_config.get('params')
+        )
         json_data = {
             "blocks": [
                 {

--- a/api/sentry/utils.py
+++ b/api/sentry/utils.py
@@ -1,6 +1,7 @@
 import json
 import csv
 import argparse
+import tomllib
 from pathlib import Path
 import requests
 import yaml
@@ -8,60 +9,8 @@ import yaml
 from utils.datetime_utils import DatetimeUtils
 
 
-project_config = {
-    "firefox-ios": {
-        "icon": ":testops-apple:",
-        "product": "Firefox iOS",
-        "looker_dashboard_url": (
-            "https://mozilla.cloud.looker.com/dashboards/"
-            "2667?Sentry+Project+ID=6176941&Created+Month=30+days"
-        ),
-        "confluence_report_url": (
-            "https://mozilla-hub.atlassian.net/wiki/spaces/"
-            "MTE/pages/1631911951/iO+Health+Monitor+Report"
-        ),
-        "sentry_url": (
-            "https://mozilla.sentry.io/explore/releases/?"
-            "environment=Production&project=6176941&"
-            "query=release.package%3Aorg.mozilla.ios.Firefox&"
-            "statsPeriod=14d"
-        )
-    },
-    "fenix": {
-        "icon": ":testops-android:",
-        "product": "Firefox Android",
-        "looker_dashboard_url": (
-            "https://mozilla.cloud.looker.com/dashboards/"
-            "2667?Sentry+Project+ID=6375561&Created+Month=30+days"
-        ),
-        "confluence_report_url": (
-            "https://mozilla-hub.atlassian.net/wiki/spaces/"
-            "MTE/pages/1695154291/Android+Health+Monitor+Report"
-        ),
-        "sentry_url": (
-            "https://mozilla.sentry.io/explore/releases/?"
-            "project=6375561&query=release.package%3Aorg.mozilla.firefox"
-            "&statsPeriod=14d"
-        )
-    },
-    "fenix-beta": {
-        "icon": ":testops-android:",
-        "product": "Firefox Android (Beta)",
-        "looker_dashboard_url": (
-            "https://mozilla.cloud.looker.com/dashboards/"
-            "2667?Sentry+Project+ID=6295551&Created+Month=30+days"
-        ),
-        "confluence_report_url": (
-            "https://mozilla-hub.atlassian.net/wiki/spaces/"
-            "MTE/pages/1695154291/Android+Health+Monitor+Report"
-        ),
-        "sentry_url": (
-            "https://mozilla.sentry.io/explore/releases/?"
-            "project=6295551&query=release.package%3Aorg.mozilla.firefox_beta"
-            "&statsPeriod=14d"
-        )
-    }
-}
+with open('config/sentry/projects.toml', 'rb') as f:
+    project_config = tomllib.load(f)
 
 
 def get_all_future_versions():

--- a/api/sentry/utils.py
+++ b/api/sentry/utils.py
@@ -10,8 +10,15 @@ import yaml
 from utils.datetime_utils import DatetimeUtils
 
 
-with open('config/sentry/projects.toml', 'rb') as f:
-    project_config = tomllib.load(f)
+try:
+    with open('config/sentry/projects.toml', 'rb') as f:
+        project_config = tomllib.load(f)
+except FileNotFoundError:
+    raise FileNotFoundError("config/sentry/projects.toml not found")
+except PermissionError:
+    raise PermissionError("Permission denied reading config/sentry/projects.toml")
+except tomllib.TOMLDecodeError:
+    raise
 
 
 def build_url(base_url: str, params: dict | None = None) -> str:

--- a/config/sentry/projects.toml
+++ b/config/sentry/projects.toml
@@ -1,20 +1,68 @@
 [firefox-ios]
 icon = ":testops-apple:"
 product = "Firefox iOS"
-looker_dashboard_url = "https://mozilla.cloud.looker.com/dashboards/2667?Sentry+Project+ID=6176941&Created+Month=30+days"
-confluence_report_url = "https://mozilla-hub.atlassian.net/wiki/spaces/MTE/pages/1631911951/iO+Health+Monitor+Report"
-sentry_url = "https://mozilla.sentry.io/explore/releases/?environment=Production&project=6176941&query=release.package%3Aorg.mozilla.ios.Firefox&statsPeriod=14d"
+
+[firefox-ios.looker]
+base_url = "https://mozilla.cloud.looker.com/dashboards/2667"
+
+[firefox-ios.looker.params]
+"Sentry Project ID" = "6176941"
+"Created Month" = "30 days"
+
+[firefox-ios.confluence]
+url = "https://mozilla-hub.atlassian.net/wiki/spaces/MTE/pages/1631911951/iO+Health+Monitor+Report"
+
+[firefox-ios.sentry]
+base_url = "https://mozilla.sentry.io/explore/releases/"
+
+[firefox-ios.sentry.params]
+environment = "Production"
+project = "6176941"
+query = "release.package:org.mozilla.ios.Firefox"
+statsPeriod = "14d"
+
 
 [fenix]
 icon = ":testops-android:"
 product = "Firefox Android"
-looker_dashboard_url = "https://mozilla.cloud.looker.com/dashboards/2667?Sentry+Project+ID=6375561&Created+Month=30+days"
-confluence_report_url = "https://mozilla-hub.atlassian.net/wiki/spaces/MTE/pages/1695154291/Android+Health+Monitor+Report"
-sentry_url = "https://mozilla.sentry.io/explore/releases/?project=6375561&query=release.package%3Aorg.mozilla.firefox&statsPeriod=14d"
+
+[fenix.looker]
+base_url = "https://mozilla.cloud.looker.com/dashboards/2667"
+
+[fenix.looker.params]
+"Sentry Project ID" = "6375561"
+"Created Month" = "30 days"
+
+[fenix.confluence]
+url = "https://mozilla-hub.atlassian.net/wiki/spaces/MTE/pages/1695154291/Android+Health+Monitor+Report"
+
+[fenix.sentry]
+base_url = "https://mozilla.sentry.io/explore/releases/"
+
+[fenix.sentry.params]
+project = "6375561"
+query = "release.package:org.mozilla.firefox"
+statsPeriod = "14d"
+
 
 [fenix-beta]
 icon = ":testops-android:"
 product = "Firefox Android (Beta)"
-looker_dashboard_url = "https://mozilla.cloud.looker.com/dashboards/2667?Sentry+Project+ID=6295551&Created+Month=30+days"
-confluence_report_url = "https://mozilla-hub.atlassian.net/wiki/spaces/MTE/pages/1695154291/Android+Health+Monitor+Report"
-sentry_url = "https://mozilla.sentry.io/explore/releases/?project=6295551&query=release.package%3Aorg.mozilla.firefox_beta&statsPeriod=14d"
+
+[fenix-beta.looker]
+base_url = "https://mozilla.cloud.looker.com/dashboards/2667"
+
+[fenix-beta.looker.params]
+"Sentry Project ID" = "6295551"
+"Created Month" = "30 days"
+
+[fenix-beta.confluence]
+url = "https://mozilla-hub.atlassian.net/wiki/spaces/MTE/pages/1695154291/Android+Health+Monitor+Report"
+
+[fenix-beta.sentry]
+base_url = "https://mozilla.sentry.io/explore/releases/"
+
+[fenix-beta.sentry.params]
+project = "6295551"
+query = "release.package:org.mozilla.firefox_beta"
+statsPeriod = "14d"

--- a/config/sentry/projects.toml
+++ b/config/sentry/projects.toml
@@ -1,0 +1,20 @@
+[firefox-ios]
+icon = ":testops-apple:"
+product = "Firefox iOS"
+looker_dashboard_url = "https://mozilla.cloud.looker.com/dashboards/2667?Sentry+Project+ID=6176941&Created+Month=30+days"
+confluence_report_url = "https://mozilla-hub.atlassian.net/wiki/spaces/MTE/pages/1631911951/iO+Health+Monitor+Report"
+sentry_url = "https://mozilla.sentry.io/explore/releases/?environment=Production&project=6176941&query=release.package%3Aorg.mozilla.ios.Firefox&statsPeriod=14d"
+
+[fenix]
+icon = ":testops-android:"
+product = "Firefox Android"
+looker_dashboard_url = "https://mozilla.cloud.looker.com/dashboards/2667?Sentry+Project+ID=6375561&Created+Month=30+days"
+confluence_report_url = "https://mozilla-hub.atlassian.net/wiki/spaces/MTE/pages/1695154291/Android+Health+Monitor+Report"
+sentry_url = "https://mozilla.sentry.io/explore/releases/?project=6375561&query=release.package%3Aorg.mozilla.firefox&statsPeriod=14d"
+
+[fenix-beta]
+icon = ":testops-android:"
+product = "Firefox Android (Beta)"
+looker_dashboard_url = "https://mozilla.cloud.looker.com/dashboards/2667?Sentry+Project+ID=6295551&Created+Month=30+days"
+confluence_report_url = "https://mozilla-hub.atlassian.net/wiki/spaces/MTE/pages/1695154291/Android+Health+Monitor+Report"
+sentry_url = "https://mozilla.sentry.io/explore/releases/?project=6295551&query=release.package%3Aorg.mozilla.firefox_beta&statsPeriod=14d"


### PR DESCRIPTION
* Use a configuration file to store the platform specific Sentry URLs
* Use query param for the Github repo URL

Fix #315 

✅ Workflow with the changes in `.py` and uses preflight: https://github.com/mozilla-mobile/testops-dashboard/actions/runs/23329730174
https://mozilla.slack.com/archives/C016BC5FUHJ/p1773982786890069