### PR TITLE
Bugfix: fenix-beta version no longer uses "environment"

### DIFF
--- a/.github/workflows/production-daily.yml
+++ b/.github/workflows/production-daily.yml
@@ -100,16 +100,19 @@ jobs:
         continue-on-error: true
 
       - name: Construct JSON for Slack (iOS)
+        id: construct-json-firefox-ios
         run: |
           python -m api.sentry.utils --file ./sentry_rates.csv --project firefox-ios
+          echo "has_data=$([ $(wc -l < sentry_rates.csv) -gt 1 ] && echo true || echo false)" >> $GITHUB_OUTPUT
         continue-on-error: true
 
       - name: Send health notification to Slack (iOS)
         id: slack-sentry-ios
+        if: steps.construct-json-firefox-ios.outputs.has_data == 'true'
         uses: slackapi/slack-github-action@v3.0.1
         with:
           payload-file-path: "./sentry-slack-firefox-ios.json"
-          payload-templated: true 
+          payload-templated: true
           webhook:  ${{ secrets.SLACK_WEBHOOK_FIREFOX_IOS_DEV }}
           webhook-type: incoming-webhook
         continue-on-error: true

--- a/.github/workflows/staging-daily.yml
+++ b/.github/workflows/staging-daily.yml
@@ -110,16 +110,19 @@ jobs:
           python __main__.py --report-type sentry-rates --project fenix
 
       - name: Construct JSON for Slack (Android)
+        id: construct-json-fenix
         run: |
           python -m api.sentry.utils --file ./sentry_rates.csv --project fenix
           ls sentry-slack-fenix.json
+          echo "has_data=$([ $(wc -l < sentry_rates.csv) -gt 1 ] && echo true || echo false)" >> $GITHUB_OUTPUT
 
       - name: Send health notification to Slack (Android)
         id: slack-sentry-fenix
+        if: steps.construct-json-fenix.outputs.has_data == 'true'
         uses: slackapi/slack-github-action@v3.0.1
         with:
           payload-file-path: "./sentry-slack-fenix.json"
-          payload-templated: true 
+          payload-templated: true
           webhook:  ${{ secrets.SLACK_WEBHOOK_PRODUCT_HEALTH }}
           webhook-type: incoming-webhook
 
@@ -128,11 +131,14 @@ jobs:
           python __main__.py --report-type sentry-issues --project fenix-beta
           python __main__.py --report-type sentry-rates --project fenix-beta
       - name: Construct JSON for Slack (Android Beta)
+        id: construct-json-fenix-beta
         run: |
           python -m api.sentry.utils --file ./sentry_rates.csv --project fenix-beta
           ls sentry-slack-fenix-beta.json
+          echo "has_data=$([ $(wc -l < sentry_rates.csv) -gt 1 ] && echo true || echo false)" >> $GITHUB_OUTPUT
       - name: Send health notification to Slack (Android Beta)
         id: slack-sentry-fenix-beta
+        if: steps.construct-json-fenix-beta.outputs.has_data == 'true'
         uses: slackapi/slack-github-action@v3.0.1
         with:
           payload-file-path: "./sentry-slack-fenix-beta.json"

--- a/api/sentry/api_sentry.py
+++ b/api/sentry/api_sentry.py
@@ -226,9 +226,14 @@ class SentryClient(Sentry):
                 )
 
         if df_rates.empty:
-            raise ValueError(
-                "No rates retrieved for project '{0}'.".format(
-                    self.sentry_project))
+            print("Warning: No rates retrieved for project '{0}', generating empty CSV.".format(
+                self.sentry_project))
+            pd.DataFrame(columns=[
+                "crash_free_rate_user", "crash_free_rate_session",
+                "adoption_rate_user", "release_version",
+                "created_at", "sentry_project_id"
+            ]).to_csv("sentry_rates.csv", index=False)
+            return
 
         # Output for Slack message
         df_rates.to_csv(
@@ -251,6 +256,7 @@ class SentryClient(Sentry):
             major_version = int(version['major'])
             build_code = version['buildCode']
             if self.sentry_project == 'fenix-beta':
+                print("%s %s %s" % (major_version, latest_major_version, int(build_code)))
                 if major_version >= latest_major_version and int(build_code) % 2 == 1:
                     payload.append(raw_version)
             else:

--- a/api/sentry/api_sentry.py
+++ b/api/sentry/api_sentry.py
@@ -260,9 +260,6 @@ class SentryClient(Sentry):
             major_version = int(version['major'])
             build_code = version['buildCode']
             if self.sentry_project == 'fenix-beta':
-                print(
-                    "%s %s %s" % (major_version, latest_major_version, int(build_code))
-                )
                 if major_version >= latest_major_version and int(build_code) % 2 == 1:
                     payload.append(raw_version)
             else:

--- a/api/sentry/api_sentry.py
+++ b/api/sentry/api_sentry.py
@@ -226,8 +226,10 @@ class SentryClient(Sentry):
                 )
 
         if df_rates.empty:
-            print("Warning: No rates retrieved for project '{0}', generating empty CSV.".format(
-                self.sentry_project))
+            print(
+                "Warning: No rates retrieved for project '{0}', generating empty CSV."
+                .format(self.sentry_project)
+            )
             pd.DataFrame(columns=[
                 "crash_free_rate_user", "crash_free_rate_session",
                 "adoption_rate_user", "release_version",
@@ -256,7 +258,9 @@ class SentryClient(Sentry):
             major_version = int(version['major'])
             build_code = version['buildCode']
             if self.sentry_project == 'fenix-beta':
-                print("%s %s %s" % (major_version, latest_major_version, int(build_code)))
+                print(
+                    "%s %s %s" % (major_version, latest_major_version, int(build_code))
+                )
                 if major_version >= latest_major_version and int(build_code) % 2 == 1:
                     payload.append(raw_version)
             else:

--- a/api/sentry/api_sentry.py
+++ b/api/sentry/api_sentry.py
@@ -82,13 +82,15 @@ class Sentry:
     # &query=release.package:{{package}}&status=open&summaryStatsPeriod=24h
     # &sort=adoption&adoptionStages=adopted
     def releases(self):
+        env_param = f'&environment={self.environment}' if self.environment else ''
         return self.client.http_get(
             (
                 '/organizations/mozilla/releases/'
-                '?adoptionStages=1&project={1}&environment={0}'
-                '&query=release.package:{2}&status=open&summaryStatsPeriod=7d'
+                f'?adoptionStages=1&project={self.sentry_project_id}{env_param}'
+                f'&query=release.package:{self.package}'
+                '&status=open&summaryStatsPeriod=7d'
                 '&adoptionStages=1&sort=adoption'
-            ).format(self.environment, self.sentry_project_id, self.package)
+            )
         )
 
     # Workaround: Get the largest/latest version through whattrainisitnow

--- a/api/sentry/api_sentry.py
+++ b/api/sentry/api_sentry.py
@@ -82,15 +82,13 @@ class Sentry:
     # &query=release.package:{{package}}&status=open&summaryStatsPeriod=24h
     # &sort=adoption&adoptionStages=adopted
     def releases(self):
-        env_param = f'&environment={self.environment}' if self.environment else ''
         return self.client.http_get(
             (
                 '/organizations/mozilla/releases/'
-                f'?adoptionStages=1&project={self.sentry_project_id}{env_param}'
-                f'&query=release.package:{self.package}'
-                '&status=open&summaryStatsPeriod=7d'
+                '?adoptionStages=1&project={1}&environment={0}'
+                '&query=release.package:{2}&status=open&summaryStatsPeriod=7d'
                 '&adoptionStages=1&sort=adoption'
-            )
+            ).format(self.environment, self.sentry_project_id, self.package)
         )
 
     # Workaround: Get the largest/latest version through whattrainisitnow


### PR DESCRIPTION
The product health notification for fenix-beta failed starting in v151 because v151 has been created but has not been released yet. 😅 
https://github.com/mozilla-mobile/testops-dashboard/actions/runs/24768613064

This PR will skip the product that don't have any rates reported instead of returning an error.