### PR TITLE
Use production workflow to send Slack message for fenix and fenix-beta product health

### DIFF
--- a/.github/workflows/production-daily.yml
+++ b/.github/workflows/production-daily.yml
@@ -121,14 +121,72 @@ jobs:
         run: |
           python __main__.py --report-type sentry-issues --project fenix
           python __main__.py --report-type sentry-rates --project fenix
+      - name: Construct JSON for Slack (Android)
+        id: construct-json-fenix
+        run: |
+          python -m api.sentry.utils --file ./sentry_rates.csv --project fenix
+          ls sentry-slack-fenix.json
+          echo "has_data=$([ $(wc -l < sentry_rates.csv) -gt 1 ] && echo true || echo false)" >> $GITHUB_OUTPUT
+      - name: Send health notification to Slack (Android)
+        id: slack-sentry-fenix
+        if: steps.construct-json-fenix.outputs.has_data == 'true'
+        uses: slackapi/slack-github-action@v3.0.1
+        with:
+          payload-file-path: "./sentry-slack-fenix.json"
+          payload-templated: true
+          webhook:  ${{ secrets.SLACK_WEBHOOK_PRODUCT_HEALTH }}
+          webhook-type: incoming-webhook
 
       - name: Sentry query (Android Beta)
         run: |
           python __main__.py --report-type sentry-issues --project fenix-beta
           python __main__.py --report-type sentry-rates --project fenix-beta
-      
-      # Note: We have sent the Android and Android Beta notifications to 
-      # mobile-alerts-product-health channel.
+      - name: Construct JSON for Slack (Android Beta)
+        id: construct-json-fenix-beta
+        run: |
+          python -m api.sentry.utils --file ./sentry_rates.csv --project fenix-beta
+          ls sentry-slack-fenix-beta.json
+          echo "has_data=$([ $(wc -l < sentry_rates.csv) -gt 1 ] && echo true || echo false)" >> $GITHUB_OUTPUT
+      - name: Send health notification to Slack (Android Beta)
+        id: slack-sentry-fenix-beta
+        if: steps.construct-json-fenix-beta.outputs.has_data == 'true'
+        uses: slackapi/slack-github-action@v3.0.1
+        with:
+          payload-file-path: "./sentry-slack-fenix-beta.json"
+          payload-templated: true
+          webhook:  ${{ secrets.SLACK_WEBHOOK_PRODUCT_HEALTH }}
+          webhook-type: incoming-webhook
+      - name: Notify Slack on any type of failure
+        if: failure()
+        uses: slackapi/slack-github-action@v3.0.1
+        with:
+          payload: |
+            {
+              "text": ":x: *Sentry report failed*\nWorkflow: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }} #${{ github.run_number }}>",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":x: *Sentry report failed*\nWorkflow: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }} #${{ github.run_number }}>"
+                  }
+                },
+                {
+                  "type": "divider"
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "mrkdwn",
+                      "text": ":testops-notify: Created by Mobile Test Engineering"
+                    }
+                  ]
+                }
+              ]
+            }
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL_TEST_ALERTS_SANDBOX }}
+          webhook-type: incoming-webhook
 
   notify:
     name: Send workflow status notification

--- a/.github/workflows/staging-daily.yml
+++ b/.github/workflows/staging-daily.yml
@@ -108,23 +108,12 @@ jobs:
         run: |
           python __main__.py --report-type sentry-issues --project fenix
           python __main__.py --report-type sentry-rates --project fenix
-
       - name: Construct JSON for Slack (Android)
         id: construct-json-fenix
         run: |
           python -m api.sentry.utils --file ./sentry_rates.csv --project fenix
           ls sentry-slack-fenix.json
           echo "has_data=$([ $(wc -l < sentry_rates.csv) -gt 1 ] && echo true || echo false)" >> $GITHUB_OUTPUT
-
-      - name: Send health notification to Slack (Android)
-        id: slack-sentry-fenix
-        if: steps.construct-json-fenix.outputs.has_data == 'true'
-        uses: slackapi/slack-github-action@v3.0.1
-        with:
-          payload-file-path: "./sentry-slack-fenix.json"
-          payload-templated: true
-          webhook:  ${{ secrets.SLACK_WEBHOOK_PRODUCT_HEALTH }}
-          webhook-type: incoming-webhook
 
       - name: Sentry query (Android Beta)
         run: |
@@ -136,15 +125,7 @@ jobs:
           python -m api.sentry.utils --file ./sentry_rates.csv --project fenix-beta
           ls sentry-slack-fenix-beta.json
           echo "has_data=$([ $(wc -l < sentry_rates.csv) -gt 1 ] && echo true || echo false)" >> $GITHUB_OUTPUT
-      - name: Send health notification to Slack (Android Beta)
-        id: slack-sentry-fenix-beta
-        if: steps.construct-json-fenix-beta.outputs.has_data == 'true'
-        uses: slackapi/slack-github-action@v3.0.1
-        with:
-          payload-file-path: "./sentry-slack-fenix-beta.json"
-          payload-templated: true
-          webhook:  ${{ secrets.SLACK_WEBHOOK_PRODUCT_HEALTH }}
-          webhook-type: incoming-webhook
+
       - name: Notify Slack on any type of failure
         if: failure()
         uses: slackapi/slack-github-action@v3.0.1

--- a/.github/workflows/staging-daily.yml
+++ b/.github/workflows/staging-daily.yml
@@ -109,22 +109,18 @@ jobs:
           python __main__.py --report-type sentry-issues --project fenix
           python __main__.py --report-type sentry-rates --project fenix
       - name: Construct JSON for Slack (Android)
-        id: construct-json-fenix
         run: |
           python -m api.sentry.utils --file ./sentry_rates.csv --project fenix
           ls sentry-slack-fenix.json
-          echo "has_data=$([ $(wc -l < sentry_rates.csv) -gt 1 ] && echo true || echo false)" >> $GITHUB_OUTPUT
 
       - name: Sentry query (Android Beta)
         run: |
           python __main__.py --report-type sentry-issues --project fenix-beta
           python __main__.py --report-type sentry-rates --project fenix-beta
       - name: Construct JSON for Slack (Android Beta)
-        id: construct-json-fenix-beta
         run: |
           python -m api.sentry.utils --file ./sentry_rates.csv --project fenix-beta
           ls sentry-slack-fenix-beta.json
-          echo "has_data=$([ $(wc -l < sentry_rates.csv) -gt 1 ] && echo true || echo false)" >> $GITHUB_OUTPUT
 
       - name: Notify Slack on any type of failure
         if: failure()


### PR DESCRIPTION
We have been using the staging workflow to send the crash-free rates and adoption rates info daily. Let's use the production workflow from now on.