### PR TITLE
Fix: Upload sentry_rates.csv rather than Slack payloads to GCS for downstream LLM use

### DIFF
--- a/.github/workflows/production-daily.yml
+++ b/.github/workflows/production-daily.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Upload Firefox (iOS) Sentry data to GCS
         uses: google-github-actions/upload-cloud-storage@v3
         with:
-          path: ./sentry-slack-firefox-ios.json
+          path: ./sentry_rates.csv
           destination: testops-llm-artifacts/sentry/firefox-ios
 
       - name: Send health notification to Slack (iOS)
@@ -142,7 +142,7 @@ jobs:
       - name: Upload Firefox (Android) Sentry data to GCS
         uses: google-github-actions/upload-cloud-storage@v3
         with:
-          path: ./sentry-slack-fenix.json
+          path: ./sentry_rates.csv
           destination: testops-llm-artifacts/sentry/fenix
 
       - name: Send health notification to Slack (Android)
@@ -169,7 +169,7 @@ jobs:
       - name: Upload Firefox Beta (Android) Sentry data to GCS
         uses: google-github-actions/upload-cloud-storage@v3
         with:
-          path: ./sentry-slack-fenix-beta.json
+          path: ./sentry_rates.csv
           destination: testops-llm-artifacts/sentry/fenix-beta
 
       - name: Send health notification to Slack (Android Beta)


### PR DESCRIPTION
What we want is the raw data rather than the Slack payload, whoops.