### PR TITLE
Add MTE-4764 Include only potentially high priority issues

### DIFF
--- a/.github/workflows/staging-weekly.yml
+++ b/.github/workflows/staging-weekly.yml
@@ -38,6 +38,7 @@ env:
 jobs:
   fetch-github-issues:
     name: New Github issues
+    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -113,13 +114,13 @@ jobs:
             --project fenix \
             --mode unhandled-issues
 
-      # - name: Send unhandled issues notification to Slack (Android)
-      #   uses: slackapi/slack-github-action@v3.0.1
-      #   with:
-      #     payload-file-path: "./sentry-slack-unhandled-fenix.json"
-      #     payload-templated: true
-      #     webhook: ${{ secrets.SLACK_WEBHOOK_URL_TEST_ALERTS_SANDBOX }}
-      #     webhook-type: incoming-webhook
+      - name: Send unhandled issues notification to Slack (Android)
+        uses: slackapi/slack-github-action@v3.0.1
+        with:
+          payload-file-path: "./sentry-slack-unhandled-fenix.json"
+          payload-templated: true
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL_TEST_ALERTS_SANDBOX }}
+          webhook-type: incoming-webhook
 
       # - name: Sentry unhandled issues query (Android Beta)
       #   run: python __main__.py --report-type sentry-unhandled-issues --project fenix-beta

--- a/.github/workflows/staging-weekly.yml
+++ b/.github/workflows/staging-weekly.yml
@@ -103,15 +103,15 @@ jobs:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_TEST_ALERTS_SANDBOX }}
           webhook-type: incoming-webhook
 
-      # - name: Sentry unhandled issues query (Android)
-      #   run: python __main__.py --report-type sentry-unhandled-issues --project fenix
+      - name: Sentry unhandled issues query (Android)
+        run: python __main__.py --report-type sentry-unhandled-issues --project fenix
 
-      # - name: Construct JSON for Slack - unhandled issues (Android)
-      #   run: |
-      #     python -m api.sentry.utils \
-      #       --file ./sentry_unhandled_issues_fenix.csv \
-      #       --project fenix \
-      #       --mode unhandled-issues
+      - name: Construct JSON for Slack - unhandled issues (Android)
+        run: |
+          python -m api.sentry.utils \
+            --file ./sentry_unhandled_issues_fenix.csv \
+            --project fenix \
+            --mode unhandled-issues
 
       # - name: Send unhandled issues notification to Slack (Android)
       #   uses: slackapi/slack-github-action@v3.0.1

--- a/.github/workflows/staging-weekly.yml
+++ b/.github/workflows/staging-weekly.yml
@@ -38,7 +38,6 @@ env:
 jobs:
   fetch-github-issues:
     name: New Github issues
-    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/staging-weekly.yml
+++ b/.github/workflows/staging-weekly.yml
@@ -104,23 +104,23 @@ jobs:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_TEST_ALERTS_SANDBOX }}
           webhook-type: incoming-webhook
 
-      - name: Sentry unhandled issues query (Android)
-        run: python __main__.py --report-type sentry-unhandled-issues --project fenix
+      # - name: Sentry unhandled issues query (Android)
+      #   run: python __main__.py --report-type sentry-unhandled-issues --project fenix
 
-      - name: Construct JSON for Slack - unhandled issues (Android)
-        run: |
-          python -m api.sentry.utils \
-            --file ./sentry_unhandled_issues_fenix.csv \
-            --project fenix \
-            --mode unhandled-issues
+      # - name: Construct JSON for Slack - unhandled issues (Android)
+      #   run: |
+      #     python -m api.sentry.utils \
+      #       --file ./sentry_unhandled_issues_fenix.csv \
+      #       --project fenix \
+      #       --mode unhandled-issues
 
-      - name: Send unhandled issues notification to Slack (Android)
-        uses: slackapi/slack-github-action@v3.0.1
-        with:
-          payload-file-path: "./sentry-slack-unhandled-fenix.json"
-          payload-templated: true
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL_TEST_ALERTS_SANDBOX }}
-          webhook-type: incoming-webhook
+      # - name: Send unhandled issues notification to Slack (Android)
+      #   uses: slackapi/slack-github-action@v3.0.1
+      #   with:
+      #     payload-file-path: "./sentry-slack-unhandled-fenix.json"
+      #     payload-templated: true
+      #     webhook: ${{ secrets.SLACK_WEBHOOK_URL_TEST_ALERTS_SANDBOX }}
+      #     webhook-type: incoming-webhook
 
       # - name: Sentry unhandled issues query (Android Beta)
       #   run: python __main__.py --report-type sentry-unhandled-issues --project fenix-beta

--- a/api/sentry/api_sentry.py
+++ b/api/sentry/api_sentry.py
@@ -6,6 +6,7 @@
 
 import os
 import sys
+import tomllib
 import requests
 import pandas as pd
 from urllib.parse import quote
@@ -62,6 +63,16 @@ class Sentry:
             missing = e.args[0]
             print(f"ERROR: Missing environment variable {missing}")
             sys.exit(1)
+
+        try:
+            with open('config/sentry/projects.toml', 'rb') as f:
+                _projects_config = tomllib.load(f)
+            self.excluded_issue_titles = (
+                _projects_config.get(project, {})
+                .get('excluded_issue_titles', [])
+            )
+        except (FileNotFoundError, tomllib.TOMLDecodeError):
+            self.excluded_issue_titles = []
 
     # API: Issues
     # Only the unassigned issues past day sorted by frequency:
@@ -214,7 +225,7 @@ class SentryClient(Sentry):
         # Insert into database
         self.db.issue_insert(df_issues)
 
-    def sentry_unhandled_issues(self, limit=5):
+    def sentry_unhandled_issues(self, limit=3):
         print("SentryClient.sentry_unhandled_issues()")
         if self.sentry_project == 'fenix-beta':
             latest_version = self.get_future_train_release()[0]
@@ -222,10 +233,18 @@ class SentryClient(Sentry):
             latest_version = self.get_latest_train_release()[-1]
         release_version = f'{self.package}@{latest_version}'
         print(f"Filtering by release: {release_version}")
-        issues = (
-            self.unhandled_issues(limit=limit, release_version=release_version)
+        fetch_limit = limit + len(self.excluded_issue_titles) + 5
+        raw_issues = (
+            self.unhandled_issues(limit=fetch_limit, release_version=release_version)
             or []
-        )[:limit]
+        )
+        issues = [
+            issue for issue in raw_issues
+            if not any(
+                excl.lower() in issue['title'].lower()
+                for excl in self.excluded_issue_titles
+            )
+        ][:limit]
         MAX_STRING_LEN = 250
         payload = []
         for issue in issues:

--- a/api/sentry/api_sentry.py
+++ b/api/sentry/api_sentry.py
@@ -229,13 +229,20 @@ class SentryClient(Sentry):
         print("SentryClient.sentry_unhandled_issues()")
         if self.sentry_project == 'fenix-beta':
             latest_version = self.get_future_train_release()[0]
+            latest_release = f'{self.package}@{latest_version}'
         else:
-            latest_version = self.get_latest_train_release()[-1]
-        release_version = f'{self.package}@{latest_version}'
-        print(f"Filtering by release: {release_version}")
+            release_versions = self.sentry_releases()
+            if not release_versions:
+                print(
+                    f"Warning: No releases found for '{self.sentry_project}', skipping."
+                )
+                return
+            latest_release = release_versions[0]
+            latest_version = latest_release.split('@')[-1]
+        print(f"Filtering by release: {latest_release}")
         fetch_limit = limit + len(self.excluded_issue_titles) + 5
         raw_issues = (
-            self.unhandled_issues(limit=fetch_limit, release_version=release_version)
+            self.unhandled_issues(limit=fetch_limit, release_version=latest_version)
             or []
         )
         issues = [
@@ -255,7 +262,7 @@ class SentryClient(Sentry):
                 issue.get('count', 0),
                 issue.get('userCount', 0),
                 issue.get('permalink', ''),
-                release_version,
+                latest_release,
             ])
         df = pd.DataFrame(
             data=payload,
@@ -265,7 +272,6 @@ class SentryClient(Sentry):
         csv_path = f'sentry_unhandled_issues_{self.sentry_project}.csv'
         df.to_csv(csv_path, index=False)
         print(f"Unhandled issues written to {csv_path}")
-        return df
 
     def sentry_rates(self, releases=[]):
         print("SentryClient.sentry_rates()")

--- a/api/sentry/utils.py
+++ b/api/sentry/utils.py
@@ -321,6 +321,20 @@ def insert_unhandled_issues(json_data, rows):
         _create_table_header_cell("Events"),
         _create_table_header_cell("Users Affected"),
     ]
+    rows = [
+        row for row in rows
+        if int(row['user_count']) > 1000 or int(row['count']) > 1000
+    ]
+    if not rows:
+        json_data["blocks"].append({
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": ":white_check_mark: No issues exceeding 1000 events or users."
+            }
+        })
+        return json_data
+
     MAX_TITLE_DISPLAY_LEN = 50
     table_rows = []
     for row in rows:

--- a/api/sentry/utils.py
+++ b/api/sentry/utils.py
@@ -321,7 +321,7 @@ def insert_unhandled_issues(json_data, rows):
         _create_table_header_cell("Events"),
         _create_table_header_cell("Users Affected"),
     ]
-    MAX_TITLE_DISPLAY_LEN = 60
+    MAX_TITLE_DISPLAY_LEN = 50
     table_rows = []
     for row in rows:
         title = row['title']

--- a/api/sentry/utils.py
+++ b/api/sentry/utils.py
@@ -309,8 +309,7 @@ def insert_unhandled_issues(json_data, rows):
             "text": {
                 "type": "mrkdwn",
                 "text": (
-                    ":white_check_mark: No new unhandled issues "
-                    "found in the last 7 days."
+                    ":white_check_mark: No significant issue to report."
                 )
             }
         })
@@ -330,7 +329,7 @@ def insert_unhandled_issues(json_data, rows):
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": ":white_check_mark: No issues exceeding 1000 events or users."
+                "text": ":white_check_mark: No significant issue to report."
             }
         })
         return json_data

--- a/api/sentry/utils.py
+++ b/api/sentry/utils.py
@@ -321,10 +321,14 @@ def insert_unhandled_issues(json_data, rows):
         _create_table_header_cell("Events"),
         _create_table_header_cell("Users Affected"),
     ]
+    MAX_TITLE_DISPLAY_LEN = 60
     table_rows = []
     for row in rows:
+        title = row['title']
+        if len(title) > MAX_TITLE_DISPLAY_LEN:
+            title = title[:MAX_TITLE_DISPLAY_LEN] + '…'
         table_rows.append([
-            _create_table_link_cell(row['title'], row['permalink']),
+            _create_table_link_cell(title, row['permalink']),
             {"type": "raw_text", "text": str(row['count'])},
             {"type": "raw_text", "text": str(row['user_count'])},
         ])

--- a/api/sentry/utils.py
+++ b/api/sentry/utils.py
@@ -288,6 +288,20 @@ def init_json(project, shortform=False):
     return json_data
 
 
+def _create_table_link_cell(text, url):
+    return {
+        "type": "rich_text",
+        "elements": [
+            {
+                "type": "rich_text_section",
+                "elements": [
+                    {"type": "link", "url": url, "text": text}
+                ]
+            }
+        ]
+    }
+
+
 def insert_unhandled_issues(json_data, rows):
     if not rows:
         json_data["blocks"].append({
@@ -295,33 +309,29 @@ def insert_unhandled_issues(json_data, rows):
             "text": {
                 "type": "mrkdwn",
                 "text": (
-                        ":white_check_mark: No new unhandled issues "
-                        "found in the last 7 days."
-                    )
+                    ":white_check_mark: No new unhandled issues "
+                    "found in the last 7 days."
+                )
             }
         })
         return json_data
 
-    lines = []
+    header_row = [
+        _create_table_header_cell("Issue"),
+        _create_table_header_cell("Events"),
+        _create_table_header_cell("Users Affected"),
+    ]
+    table_rows = []
     for row in rows:
-        title = (row['title']
-                 .replace('&', '&amp;')
-                 .replace('<', '&lt;')
-                 .replace('>', '&gt;'))
-        count = row['count']
-        user_count = row['user_count']
-        permalink = row['permalink']
-        lines.append(
-            f"• <{permalink}|{title}> — "
-            f"{count} events, {user_count} users affected"
-        )
+        table_rows.append([
+            _create_table_link_cell(row['title'], row['permalink']),
+            {"type": "raw_text", "text": str(row['count'])},
+            {"type": "raw_text", "text": str(row['user_count'])},
+        ])
 
     json_data["blocks"].append({
-        "type": "section",
-        "text": {
-            "type": "mrkdwn",
-            "text": "\n".join(lines)
-        }
+        "type": "table",
+        "rows": [header_row] + table_rows
     })
     return json_data
 
@@ -348,7 +358,7 @@ def main_unhandled_issues(csv_file: str, project: str) -> None:
     sentry_issues_url = (
         f"https://mozilla.sentry.io/issues/?limit=5&project={project_id}"
         f"&query=error.unhandled%3Atrue%20is%3Aunresolved{release_filter}"
-        f"&environment={environment}&referrer=issue-list&sort=freq&statsPeriod=7d"
+        f"&environment={environment}&sort=freq&statsPeriod=7d"
     )
     json_data = {
         "blocks": [

--- a/api/sentry/utils.py
+++ b/api/sentry/utils.py
@@ -332,12 +332,24 @@ def main_unhandled_issues(csv_file: str, project: str) -> None:
     now = DatetimeUtils.start_date('0')
 
     version_label = ''
+    version = ''
     with open(csv_file, 'r') as f:
         rows = list(csv.DictReader(f))
     if rows and rows[0].get('release_version'):
         version = rows[0]['release_version'].split('@')[-1]
         version_label = f' v{version}'
 
+    sentry_params = project_config.get(project, {}).get('sentry', {}).get('params', {})
+    project_id = sentry_params.get('project', '')
+    environment = sentry_params.get('environment', '')
+    release_filter = (
+        f"%20release.version%3A{version}" if version else ""
+    )
+    sentry_issues_url = (
+        f"https://mozilla.sentry.io/issues/?limit=5&project={project_id}"
+        f"&query=error.unhandled%3Atrue%20is%3Aunresolved{release_filter}"
+        f"&environment={environment}&referrer=issue-list&sort=freq&statsPeriod=7d"
+    )
     json_data = {
         "blocks": [
             {
@@ -346,7 +358,7 @@ def main_unhandled_issues(csv_file: str, project: str) -> None:
                     "type": "mrkdwn",
                     "text": (
                         f"*:sentry: {icon} {product}{version_label} "
-                        f"Top Sentry Issues ({now})*"
+                        f"<{sentry_issues_url}|Top Sentry Issues> ({now})*"
                     )
                 }
             }

--- a/config/sentry/projects.toml
+++ b/config/sentry/projects.toml
@@ -1,6 +1,7 @@
 [firefox-ios]
 icon = ":testops-apple:"
 product = "Firefox iOS"
+excluded_issue_titles = ["WatchdogTermination"]
 
 [firefox-ios.looker]
 base_url = "https://mozilla.cloud.looker.com/dashboards/2667"


### PR DESCRIPTION
A few updates from the first report:
* Only include at most top 3 issues that affect more than 1000 users or had more than 1000 events
* Present the issue in a table
* Exclude the top frequently occurred "WatchdogTermination" issue. (The developers can't act on it.)
* Add Sentry link to the title
<img width="660" height="161" alt="Screenshot 2026-04-29 at 13 41 35" src="https://github.com/user-attachments/assets/21e23994-25d6-43dd-b6df-5c4a89dc403c" />
