### PR TITLE
Refactor MTE-4764 Fetch Sentry issues for all versions

### DIFF
--- a/api/sentry/api_sentry.py
+++ b/api/sentry/api_sentry.py
@@ -9,7 +9,6 @@ import sys
 import tomllib
 import requests
 import pandas as pd
-from urllib.parse import quote
 
 from packaging.version import Version
 from lib.sentry_conn import APIClient
@@ -114,12 +113,10 @@ class Sentry:
         return list(response.json().keys())
 
     # API: Top unhandled issues sorted by frequency over the past 7 days
-    def unhandled_issues(self, limit=5, release_version=None):
+    def unhandled_issues(self, limit=5):
         query = (
             'error.unhandled%3Atrue%20is%3Aunresolved'
         )
-        if release_version:
-            query += '%20release.version%3A' + quote(release_version, safe='')
         return self.client.http_get(
             (
                 'organizations/{0}/issues/'

--- a/api/sentry/api_sentry.py
+++ b/api/sentry/api_sentry.py
@@ -239,10 +239,10 @@ class SentryClient(Sentry):
                 return
             latest_release = release_versions[0]
             latest_version = latest_release.split('@')[-1]
-        print(f"Filtering by release: {latest_release}")
+        print(f"Latest release (for reference): {latest_release}")
         fetch_limit = limit + len(self.excluded_issue_titles) + 5
         raw_issues = (
-            self.unhandled_issues(limit=fetch_limit, release_version=latest_version)
+            self.unhandled_issues(limit=fetch_limit)
             or []
         )
         issues = [

--- a/api/sentry/api_sentry.py
+++ b/api/sentry/api_sentry.py
@@ -227,19 +227,6 @@ class SentryClient(Sentry):
 
     def sentry_unhandled_issues(self, limit=3):
         print("SentryClient.sentry_unhandled_issues()")
-        if self.sentry_project == 'fenix-beta':
-            latest_version = self.get_future_train_release()[0]
-            latest_release = f'{self.package}@{latest_version}'
-        else:
-            release_versions = self.sentry_releases()
-            if not release_versions:
-                print(
-                    f"Warning: No releases found for '{self.sentry_project}', skipping."
-                )
-                return
-            latest_release = release_versions[0]
-            latest_version = latest_release.split('@')[-1]
-        print(f"Latest release (for reference): {latest_release}")
         fetch_limit = limit + len(self.excluded_issue_titles) + 5
         raw_issues = (
             self.unhandled_issues(limit=fetch_limit)
@@ -262,12 +249,11 @@ class SentryClient(Sentry):
                 issue.get('count', 0),
                 issue.get('userCount', 0),
                 issue.get('permalink', ''),
-                latest_release,
             ])
         df = pd.DataFrame(
             data=payload,
             columns=['sentry_id', 'title', 'culprit', 'count',
-                     'user_count', 'permalink', 'release_version']
+                     'user_count', 'permalink']
         )
         csv_path = f'sentry_unhandled_issues_{self.sentry_project}.csv'
         df.to_csv(csv_path, index=False)

--- a/api/sentry/api_sentry.py
+++ b/api/sentry/api_sentry.py
@@ -116,10 +116,10 @@ class Sentry:
     # API: Top unhandled issues sorted by frequency over the past 7 days
     def unhandled_issues(self, limit=5, release_version=None):
         query = (
-            'error.unhandled%3Atrue+is%3Aunresolved'
+            'error.unhandled%3Atrue%20is%3Aunresolved'
         )
         if release_version:
-            query += '+release.version%3A' + quote(release_version, safe='')
+            query += '%20release.version%3A' + quote(release_version, safe='')
         return self.client.http_get(
             (
                 'organizations/{0}/issues/'

--- a/api/sentry/utils.py
+++ b/api/sentry/utils.py
@@ -358,13 +358,8 @@ def main_unhandled_issues(csv_file: str, project: str) -> None:
     product = project_config.get(project).get('product')
     now = DatetimeUtils.start_date('0')
 
-    version_label = ''
     with open(csv_file, 'r') as f:
         rows = list(csv.DictReader(f))
-    if rows and rows[0].get('release_version'):
-        version = rows[0]['release_version'].split('@')[-1].split('+')[0]
-        major_version = version.split('.')[0]
-        version_label = f' v{major_version}.x'
 
     sentry_params = project_config.get(project, {}).get('sentry', {}).get('params', {})
     project_id = sentry_params.get('project', '')
@@ -381,7 +376,7 @@ def main_unhandled_issues(csv_file: str, project: str) -> None:
                 "text": {
                     "type": "mrkdwn",
                     "text": (
-                        f"*:sentry: {icon} {product}{version_label} "
+                        f"*:sentry: {icon} {product} "
                         f"<{sentry_issues_url}|Top Sentry Issues> ({now})*"
                     )
                 }

--- a/api/sentry/utils.py
+++ b/api/sentry/utils.py
@@ -359,22 +359,19 @@ def main_unhandled_issues(csv_file: str, project: str) -> None:
     now = DatetimeUtils.start_date('0')
 
     version_label = ''
-    version = ''
     with open(csv_file, 'r') as f:
         rows = list(csv.DictReader(f))
     if rows and rows[0].get('release_version'):
-        version = rows[0]['release_version'].split('@')[-1]
-        version_label = f' v{version}'
+        version = rows[0]['release_version'].split('@')[-1].split('+')[0]
+        major_version = version.split('.')[0]
+        version_label = f' v{major_version}.x'
 
     sentry_params = project_config.get(project, {}).get('sentry', {}).get('params', {})
     project_id = sentry_params.get('project', '')
     environment = sentry_params.get('environment', '')
-    release_filter = (
-        f"%20release.version%3A{version}" if version else ""
-    )
     sentry_issues_url = (
         f"https://mozilla.sentry.io/issues/?limit=5&project={project_id}"
-        f"&query=error.unhandled%3Atrue%20is%3Aunresolved{release_filter}"
+        f"&query=error.unhandled%3Atrue%20is%3Aunresolved"
         f"&environment={environment}&sort=freq&statsPeriod=7d"
     )
     json_data = {


### PR DESCRIPTION
Instead of fetching issues from specific dot versions, let's just fetch the top 3 issues for all versions.
<img width="697" height="212" alt="Screenshot 2026-05-04 at 18 06 40" src="https://github.com/user-attachments/assets/61e78b48-6ff6-44af-b7f1-0d68c3f2a2fd" />

(The developers know about the top issue from this list.)
