### PR TITLE
Add Cs/mte 4764 Sentry issues for last 2 major versions

### DIFF
--- a/.github/workflows/staging-weekly.yml
+++ b/.github/workflows/staging-weekly.yml
@@ -95,12 +95,31 @@ jobs:
             --project firefox-ios \
             --mode unhandled-issues
 
-      - name: Send unhandled issues notification to Slack (iOS)
+      - name: Sentry unhandled issues query - short form (iOS)
         uses: slackapi/slack-github-action@v3.0.3
         with:
           payload-file-path: "./sentry-slack-unhandled-firefox-ios.json"
           payload-templated: true
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_TEST_ALERTS_SANDBOX }}
+          webhook-type: incoming-webhook
+
+      - name: Sentry unhandled issues query - long form (iOS)
+        run: python __main__.py --report-type sentry-unhandled-issues --project firefox-ios --longform
+
+      - name: Construct JSON for Slack - unhandled issues long form (iOS)
+        run: |
+          python -m api.sentry.utils \
+            --file ./sentry_unhandled_issues_long_firefox-ios.csv \
+            --project firefox-ios \
+            --mode unhandled-issues \
+            --longform
+
+      - name: Send unhandled issues long-form notification to Slack (iOS)
+        uses: slackapi/slack-github-action@v3.0.3
+        with:
+          payload-file-path: "./sentry-slack-unhandled-long-firefox-ios.json"
+          payload-templated: true
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL_MOBILE_ALERTS_SANDBOX_SENTRY }}
           webhook-type: incoming-webhook
 
       # - name: Sentry unhandled issues query (Android)

--- a/.github/workflows/staging-weekly.yml
+++ b/.github/workflows/staging-weekly.yml
@@ -114,13 +114,45 @@ jobs:
             --mode unhandled-issues \
             --longform
 
-      - name: Send unhandled issues long-form notification to Slack (iOS)
+      - name: Inject channel into long-form header (iOS)
+        run: |
+          jq --arg channel "${{ secrets.SLACK_CHANNEL_ID_MOBILE_ALERTS_SANDBOX_SENTRY }}" \
+             '. + {channel: $channel}' \
+             sentry-slack-unhandled-long-firefox-ios-header.json \
+             > sentry-slack-unhandled-long-firefox-ios-header-out.json
+
+      - name: Post long-form header to Slack (iOS)
+        id: slack-long-header-ios
         uses: slackapi/slack-github-action@v3.0.3
         with:
-          payload-file-path: "./sentry-slack-unhandled-long-firefox-ios.json"
-          payload-templated: true
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL_MOBILE_ALERTS_SANDBOX_SENTRY }}
-          webhook-type: incoming-webhook
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_TESTOPS_BOT_TOKEN }}
+          payload-file-path: "./sentry-slack-unhandled-long-firefox-ios-header-out.json"
+
+      - name: Post long-form threaded replies to Slack (iOS)
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_TESTOPS_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID_MOBILE_ALERTS_SANDBOX_SENTRY }}
+          THREAD_TS: ${{ steps.slack-long-header-ios.outputs.ts }}
+        run: |
+          set -euo pipefail
+          for f in sentry-slack-unhandled-long-firefox-ios-reply-*.json; do
+            [ -e "$f" ] || continue
+            jq --arg channel "$SLACK_CHANNEL_ID" \
+               --arg thread_ts "$THREAD_TS" \
+               '. + {channel: $channel, thread_ts: $thread_ts}' \
+               "$f" > /tmp/reply-payload.json
+            response=$(curl -sS -X POST \
+              -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+              -H "Content-Type: application/json; charset=utf-8" \
+              --data @/tmp/reply-payload.json \
+              https://slack.com/api/chat.postMessage)
+            echo "$response"
+            if [ "$(echo "$response" | jq -r '.ok')" != "true" ]; then
+              echo "Slack reply failed for $f" >&2
+              exit 1
+            fi
+          done
 
       # - name: Sentry unhandled issues query (Android)
       #   run: python __main__.py --report-type sentry-unhandled-issues --project fenix

--- a/__main__.py
+++ b/__main__.py
@@ -108,6 +108,15 @@ def parse_args(cmdln_args):
         type=str,
     )
 
+    parser.add_argument(
+        "--longform",
+        help="Generate the long-form sentry-unhandled-issues report "
+             "(top issues per sub-version) instead of the default short form",
+        required=False,
+        action="store_true",
+        default=False,
+    )
+
     return parser.parse_args(args=cmdln_args)
 
 

--- a/api/sentry/api_sentry.py
+++ b/api/sentry/api_sentry.py
@@ -260,6 +260,7 @@ class SentryClient(Sentry):
             for issue in issues:
                 payload.append([
                     issue['id'],
+                    issue.get('shortId', ''),
                     issue['title'][:MAX_STRING_LEN],
                     issue.get('culprit', ''),
                     issue.get('count', 0),
@@ -269,7 +270,7 @@ class SentryClient(Sentry):
                 ])
         df = pd.DataFrame(
             data=payload,
-            columns=['sentry_id', 'title', 'culprit', 'count',
+            columns=['sentry_id', 'short_id', 'title', 'culprit', 'count',
                      'user_count', 'permalink', 'release_version']
         )
         csv_path = f'sentry_unhandled_issues_{self.sentry_project}.csv'

--- a/api/sentry/api_sentry.py
+++ b/api/sentry/api_sentry.py
@@ -224,8 +224,8 @@ class SentryClient(Sentry):
         # Insert into database
         self.db.issue_insert(df_issues)
 
-    def sentry_unhandled_issues(self, limit=3):
-        print("SentryClient.sentry_unhandled_issues()")
+    def sentry_unhandled_issues(self, limit=3, longform=False):
+        print(f"SentryClient.sentry_unhandled_issues(longform={longform})")
         if self.sentry_project == 'fenix-beta':
             release_versions = [self.get_future_train_release()[0]]
         else:
@@ -237,25 +237,33 @@ class SentryClient(Sentry):
                 )
                 return
 
-        # Query Sentry once per major version with a wildcard so the result
-        # matches the Sentry UI for release.version:<major>.* — otherwise an
-        # issue whose events are spread across multiple sub-versions ranks
-        # low in every per-sub-version query and is missed.
-        majors = sorted({
-            int(rv.split('+')[0].split('.')[0])
-            for rv in release_versions
-        }, reverse=True)
-
         fetch_limit = limit + len(self.excluded_issue_titles) + 5
         MAX_STRING_LEN = 250
         payload = []
-        for major in majors:
-            major_query = f"{major}.*"
-            print(f"Filtering by release: {major_query}")
+
+        if longform:
+            # Top N issues per exact sub-version (e.g. 151.0, 151.0.1).
+            queries = [
+                (rv.split('+')[0], rv.split('+')[0])
+                for rv in release_versions
+            ]
+        else:
+            # Top issue per major version using a wildcard query so the
+            # result matches Sentry's UI for release.version:<major>.* —
+            # otherwise an issue whose events are spread across multiple
+            # sub-versions ranks low in every per-sub-version query.
+            majors = sorted({
+                int(rv.split('+')[0].split('.')[0])
+                for rv in release_versions
+            }, reverse=True)
+            queries = [(f"{m}.*", str(m)) for m in majors]
+
+        for query_version, stored_version in queries:
+            print(f"Filtering by release: {query_version}")
             raw_issues = (
                 self.unhandled_issues(
                     limit=fetch_limit,
-                    release_version=major_query,
+                    release_version=query_version,
                 )
                 or []
             )
@@ -275,14 +283,17 @@ class SentryClient(Sentry):
                     issue.get('count', 0),
                     issue.get('userCount', 0),
                     issue.get('permalink', ''),
-                    str(major),
+                    stored_version,
                 ])
         df = pd.DataFrame(
             data=payload,
             columns=['sentry_id', 'short_id', 'title', 'culprit', 'count',
                      'user_count', 'permalink', 'release_version']
         )
-        csv_path = f'sentry_unhandled_issues_{self.sentry_project}.csv'
+        suffix = '_long' if longform else ''
+        csv_path = (
+            f'sentry_unhandled_issues{suffix}_{self.sentry_project}.csv'
+        )
         df.to_csv(csv_path, index=False)
         print(f"Unhandled issues written to {csv_path}")
 

--- a/api/sentry/api_sentry.py
+++ b/api/sentry/api_sentry.py
@@ -113,10 +113,12 @@ class Sentry:
         return list(response.json().keys())
 
     # API: Top unhandled issues sorted by frequency over the past 7 days
-    def unhandled_issues(self, limit=5):
+    def unhandled_issues(self, limit=5, release_version=None):
         query = (
             'error.unhandled%3Atrue%20is%3Aunresolved'
         )
+        if release_version:
+            query += '%20release.version%3A' + release_version
         return self.client.http_get(
             (
                 'organizations/{0}/issues/'
@@ -224,33 +226,51 @@ class SentryClient(Sentry):
 
     def sentry_unhandled_issues(self, limit=3):
         print("SentryClient.sentry_unhandled_issues()")
+        if self.sentry_project == 'fenix-beta':
+            release_versions = [self.get_future_train_release()[0]]
+        else:
+            release_versions = self.sentry_releases()
+            if not release_versions:
+                print(
+                    f"Warning: No releases found for '{self.sentry_project}', "
+                    "skipping."
+                )
+                return
+
         fetch_limit = limit + len(self.excluded_issue_titles) + 5
-        raw_issues = (
-            self.unhandled_issues(limit=fetch_limit)
-            or []
-        )
-        issues = [
-            issue for issue in raw_issues
-            if not any(
-                excl.lower() in issue['title'].lower()
-                for excl in self.excluded_issue_titles
-            )
-        ][:limit]
         MAX_STRING_LEN = 250
         payload = []
-        for issue in issues:
-            payload.append([
-                issue['id'],
-                issue['title'][:MAX_STRING_LEN],
-                issue.get('culprit', ''),
-                issue.get('count', 0),
-                issue.get('userCount', 0),
-                issue.get('permalink', ''),
-            ])
+        for release_version in release_versions:
+            short_release_version = release_version.split('+')[0]
+            print(f"Filtering by release: {short_release_version}")
+            raw_issues = (
+                self.unhandled_issues(
+                    limit=fetch_limit,
+                    release_version=short_release_version,
+                )
+                or []
+            )
+            issues = [
+                issue for issue in raw_issues
+                if not any(
+                    excl.lower() in issue['title'].lower()
+                    for excl in self.excluded_issue_titles
+                )
+            ][:limit]
+            for issue in issues:
+                payload.append([
+                    issue['id'],
+                    issue['title'][:MAX_STRING_LEN],
+                    issue.get('culprit', ''),
+                    issue.get('count', 0),
+                    issue.get('userCount', 0),
+                    issue.get('permalink', ''),
+                    short_release_version,
+                ])
         df = pd.DataFrame(
             data=payload,
             columns=['sentry_id', 'title', 'culprit', 'count',
-                     'user_count', 'permalink']
+                     'user_count', 'permalink', 'release_version']
         )
         csv_path = f'sentry_unhandled_issues_{self.sentry_project}.csv'
         df.to_csv(csv_path, index=False)

--- a/api/sentry/api_sentry.py
+++ b/api/sentry/api_sentry.py
@@ -237,16 +237,25 @@ class SentryClient(Sentry):
                 )
                 return
 
+        # Query Sentry once per major version with a wildcard so the result
+        # matches the Sentry UI for release.version:<major>.* — otherwise an
+        # issue whose events are spread across multiple sub-versions ranks
+        # low in every per-sub-version query and is missed.
+        majors = sorted({
+            int(rv.split('+')[0].split('.')[0])
+            for rv in release_versions
+        }, reverse=True)
+
         fetch_limit = limit + len(self.excluded_issue_titles) + 5
         MAX_STRING_LEN = 250
         payload = []
-        for release_version in release_versions:
-            short_release_version = release_version.split('+')[0]
-            print(f"Filtering by release: {short_release_version}")
+        for major in majors:
+            major_query = f"{major}.*"
+            print(f"Filtering by release: {major_query}")
             raw_issues = (
                 self.unhandled_issues(
                     limit=fetch_limit,
-                    release_version=short_release_version,
+                    release_version=major_query,
                 )
                 or []
             )
@@ -266,7 +275,7 @@ class SentryClient(Sentry):
                     issue.get('count', 0),
                     issue.get('userCount', 0),
                     issue.get('permalink', ''),
-                    short_release_version,
+                    str(major),
                 ])
         df = pd.DataFrame(
             data=payload,

--- a/api/sentry/utils.py
+++ b/api/sentry/utils.py
@@ -319,14 +319,13 @@ def insert_unhandled_issues(
             }
         })
 
+    # Preserve the order Sentry returned (sort=freq over statsPeriod=7d).
+    # Don't re-sort by count/user_count — those are lifetime totals, so
+    # re-sorting would surface old high-volume issues over recent ones.
     significant = [
         row for row in rows
         if int(row['user_count']) > 1000 or int(row['count']) > 1000
     ]
-    significant.sort(
-        key=lambda r: (int(r['count']), int(r['user_count'])),
-        reverse=True,
-    )
     if limit is not None:
         significant = significant[:limit]
     if not significant:

--- a/api/sentry/utils.py
+++ b/api/sentry/utils.py
@@ -366,7 +366,9 @@ def insert_unhandled_issues(
     return json_data
 
 
-def main_unhandled_issues(csv_file: str, project: str) -> None:
+def main_unhandled_issues(
+    csv_file: str, project: str, longform: bool = False
+) -> None:
     icon = project_config.get(project).get('icon')
     product = project_config.get(project).get('product')
     now = DatetimeUtils.start_date('0')
@@ -382,6 +384,7 @@ def main_unhandled_issues(csv_file: str, project: str) -> None:
         f"&query=error.unhandled%3Atrue%20is%3Aunresolved"
         f"&environment={environment}&sort=freq&statsPeriod=7d"
     )
+    title_suffix = " (Detailed)" if longform else ""
     json_data = {
         "blocks": [
             {
@@ -390,44 +393,72 @@ def main_unhandled_issues(csv_file: str, project: str) -> None:
                     "type": "mrkdwn",
                     "text": (
                         f"*:sentry: {icon} {product} "
-                        f"<{sentry_issues_url}|Top Sentry Issues> ({now})*"
+                        f"<{sentry_issues_url}|Top Sentry Issues>"
+                        f"{title_suffix} ({now})*"
                     )
                 }
             }
         ]
     }
 
-    rows_by_major = {}
-    for row in rows:
-        version = row.get('release_version', '')
-        try:
-            major = Version(version).major
-        except Exception:
-            continue
-        rows_by_major.setdefault(major, []).append(row)
+    if longform:
+        rows_by_version = {}
+        for row in rows:
+            version = row.get('release_version', '')
+            rows_by_version.setdefault(version, []).append(row)
 
-    if not rows_by_major:
-        insert_unhandled_issues(json_data, [])
+        if not rows_by_version:
+            insert_unhandled_issues(json_data, [])
+        else:
+            versions = sorted(rows_by_version.keys(), key=Version, reverse=True)
+            for version in versions:
+                version_url = (
+                    f"https://mozilla.sentry.io/issues/?limit=5"
+                    f"&project={project_id}"
+                    f"&query=error.unhandled%3Atrue%20is%3Aunresolved"
+                    f"%20release.version%3A{version}"
+                    f"&environment={environment}&sort=freq&statsPeriod=7d"
+                )
+                insert_unhandled_issues(
+                    json_data,
+                    rows_by_version[version],
+                    version=version,
+                    version_url=version_url,
+                )
     else:
-        majors = sorted(rows_by_major.keys(), reverse=True)[:2]
-        for major in majors:
-            version_url = (
-                f"https://mozilla.sentry.io/issues/?limit=5&project={project_id}"
-                f"&query=error.unhandled%3Atrue%20is%3Aunresolved"
-                f"%20release.version%3A{major}.*"
-                f"&environment={environment}&sort=freq&statsPeriod=7d"
-            )
-            insert_unhandled_issues(
-                json_data,
-                rows_by_major[major],
-                version=str(major),
-                version_url=version_url,
-                limit=1,
-            )
+        rows_by_major = {}
+        for row in rows:
+            version = row.get('release_version', '')
+            try:
+                major = Version(version).major
+            except Exception:
+                continue
+            rows_by_major.setdefault(major, []).append(row)
+
+        if not rows_by_major:
+            insert_unhandled_issues(json_data, [])
+        else:
+            majors = sorted(rows_by_major.keys(), reverse=True)[:2]
+            for major in majors:
+                version_url = (
+                    f"https://mozilla.sentry.io/issues/?limit=5"
+                    f"&project={project_id}"
+                    f"&query=error.unhandled%3Atrue%20is%3Aunresolved"
+                    f"%20release.version%3A{major}.*"
+                    f"&environment={environment}&sort=freq&statsPeriod=7d"
+                )
+                insert_unhandled_issues(
+                    json_data,
+                    rows_by_major[major],
+                    version=str(major),
+                    version_url=version_url,
+                    limit=1,
+                )
 
     insert_json_footer(json_data)
 
-    output_path = Path(f'sentry-slack-unhandled-{project}.json')
+    suffix = '-long' if longform else ''
+    output_path = Path(f'sentry-slack-unhandled{suffix}-{project}.json')
     output_path.write_text(json.dumps(json_data, indent=4))
     print(f"Slack message written to {output_path.resolve()}")
 
@@ -450,12 +481,15 @@ if __name__ == '__main__':
                         help='Sentry project name (firefox-ios or fenix)')
     parser.add_argument('--shortform', action='store_true', default=False,
                         help='Generate a shorter version of the report')
+    parser.add_argument('--longform', action='store_true', default=False,
+                        help='Generate the long-form unhandled-issues report '
+                             '(top issues per sub-version)')
     parser.add_argument('--mode', default='rates',
                         choices=['rates', 'unhandled-issues'],
                         help='Report mode')
 
     args = parser.parse_args()
     if args.mode == 'unhandled-issues':
-        main_unhandled_issues(args.file, args.project)
+        main_unhandled_issues(args.file, args.project, args.longform)
     else:
         main(args.file, args.project, args.shortform)

--- a/api/sentry/utils.py
+++ b/api/sentry/utils.py
@@ -318,6 +318,10 @@ def insert_unhandled_issues(json_data, rows, version=None):
         row for row in rows
         if int(row['user_count']) > 1000 or int(row['count']) > 1000
     ]
+    significant.sort(
+        key=lambda r: (int(r['count']), int(r['user_count'])),
+        reverse=True,
+    )
     if not significant:
         json_data["blocks"].append({
             "type": "section",

--- a/api/sentry/utils.py
+++ b/api/sentry/utils.py
@@ -304,7 +304,9 @@ def _create_table_link_cell(text, url):
     }
 
 
-def insert_unhandled_issues(json_data, rows, version=None, version_url=None):
+def insert_unhandled_issues(
+    json_data, rows, version=None, version_url=None, limit=None
+):
     if version is not None:
         header_text = (
             f"*<{version_url}|v{version}>*" if version_url else f"*v{version}*"
@@ -325,6 +327,8 @@ def insert_unhandled_issues(json_data, rows, version=None, version_url=None):
         key=lambda r: (int(r['count']), int(r['user_count'])),
         reverse=True,
     )
+    if limit is not None:
+        significant = significant[:limit]
     if not significant:
         json_data["blocks"].append({
             "type": "section",
@@ -336,6 +340,7 @@ def insert_unhandled_issues(json_data, rows, version=None, version_url=None):
         return json_data
 
     header_row = [
+        _create_table_header_cell("Issue ID"),
         _create_table_header_cell("Issue"),
         _create_table_header_cell("Events"),
         _create_table_header_cell("Users Affected"),
@@ -347,7 +352,10 @@ def insert_unhandled_issues(json_data, rows, version=None, version_url=None):
         if len(title) > MAX_TITLE_DISPLAY_LEN:
             title = title[:MAX_TITLE_DISPLAY_LEN] + '…'
         table_rows.append([
-            _create_table_link_cell(title, row['permalink']),
+            _create_table_link_cell(
+                row.get('short_id', ''), row['permalink']
+            ),
+            {"type": "raw_text", "text": title},
             {"type": "raw_text", "text": str(row['count'])},
             {"type": "raw_text", "text": str(row['user_count'])},
         ])
@@ -390,27 +398,32 @@ def main_unhandled_issues(csv_file: str, project: str) -> None:
         ]
     }
 
-    rows_by_version = {}
+    rows_by_major = {}
     for row in rows:
         version = row.get('release_version', '')
-        rows_by_version.setdefault(version, []).append(row)
+        try:
+            major = Version(version).major
+        except Exception:
+            continue
+        rows_by_major.setdefault(major, []).append(row)
 
-    if not rows_by_version:
+    if not rows_by_major:
         insert_unhandled_issues(json_data, [])
     else:
-        versions = sorted(rows_by_version.keys(), key=Version, reverse=True)
-        for version in versions:
+        majors = sorted(rows_by_major.keys(), reverse=True)[:2]
+        for major in majors:
             version_url = (
                 f"https://mozilla.sentry.io/issues/?limit=5&project={project_id}"
                 f"&query=error.unhandled%3Atrue%20is%3Aunresolved"
-                f"%20release.version%3A{version}"
+                f"%20release.version%3A{major}.*"
                 f"&environment={environment}&sort=freq&statsPeriod=7d"
             )
             insert_unhandled_issues(
                 json_data,
-                rows_by_version[version],
-                version=version,
+                rows_by_major[major],
+                version=str(major),
                 version_url=version_url,
+                limit=1,
             )
 
     insert_json_footer(json_data)

--- a/api/sentry/utils.py
+++ b/api/sentry/utils.py
@@ -7,6 +7,8 @@ from urllib.parse import urlencode
 import requests
 import yaml
 
+from packaging.version import Version
+
 from utils.datetime_utils import DatetimeUtils
 
 
@@ -302,29 +304,21 @@ def _create_table_link_cell(text, url):
     }
 
 
-def insert_unhandled_issues(json_data, rows):
-    if not rows:
+def insert_unhandled_issues(json_data, rows, version=None):
+    if version is not None:
         json_data["blocks"].append({
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": (
-                    ":white_check_mark: No significant issue to report."
-                )
+                "text": f"*v{version}*"
             }
         })
-        return json_data
 
-    header_row = [
-        _create_table_header_cell("Issue"),
-        _create_table_header_cell("Events"),
-        _create_table_header_cell("Users Affected"),
-    ]
-    rows = [
+    significant = [
         row for row in rows
         if int(row['user_count']) > 1000 or int(row['count']) > 1000
     ]
-    if not rows:
+    if not significant:
         json_data["blocks"].append({
             "type": "section",
             "text": {
@@ -334,9 +328,14 @@ def insert_unhandled_issues(json_data, rows):
         })
         return json_data
 
+    header_row = [
+        _create_table_header_cell("Issue"),
+        _create_table_header_cell("Events"),
+        _create_table_header_cell("Users Affected"),
+    ]
     MAX_TITLE_DISPLAY_LEN = 50
     table_rows = []
-    for row in rows:
+    for row in significant:
         title = row['title']
         if len(title) > MAX_TITLE_DISPLAY_LEN:
             title = title[:MAX_TITLE_DISPLAY_LEN] + '…'
@@ -383,7 +382,21 @@ def main_unhandled_issues(csv_file: str, project: str) -> None:
             }
         ]
     }
-    insert_unhandled_issues(json_data, rows)
+
+    rows_by_version = {}
+    for row in rows:
+        version = row.get('release_version', '')
+        rows_by_version.setdefault(version, []).append(row)
+
+    if not rows_by_version:
+        insert_unhandled_issues(json_data, [])
+    else:
+        versions = sorted(rows_by_version.keys(), key=Version, reverse=True)
+        for version in versions:
+            insert_unhandled_issues(
+                json_data, rows_by_version[version], version=version
+            )
+
     insert_json_footer(json_data)
 
     output_path = Path(f'sentry-slack-unhandled-{project}.json')

--- a/api/sentry/utils.py
+++ b/api/sentry/utils.py
@@ -304,13 +304,16 @@ def _create_table_link_cell(text, url):
     }
 
 
-def insert_unhandled_issues(json_data, rows, version=None):
+def insert_unhandled_issues(json_data, rows, version=None, version_url=None):
     if version is not None:
+        header_text = (
+            f"*<{version_url}|v{version}>*" if version_url else f"*v{version}*"
+        )
         json_data["blocks"].append({
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": f"*v{version}*"
+                "text": header_text
             }
         })
 
@@ -397,8 +400,17 @@ def main_unhandled_issues(csv_file: str, project: str) -> None:
     else:
         versions = sorted(rows_by_version.keys(), key=Version, reverse=True)
         for version in versions:
+            version_url = (
+                f"https://mozilla.sentry.io/issues/?limit=5&project={project_id}"
+                f"&query=error.unhandled%3Atrue%20is%3Aunresolved"
+                f"%20release.version%3A{version}"
+                f"&environment={environment}&sort=freq&statsPeriod=7d"
+            )
             insert_unhandled_issues(
-                json_data, rows_by_version[version], version=version
+                json_data,
+                rows_by_version[version],
+                version=version,
+                version_url=version_url,
             )
 
     insert_json_footer(json_data)

--- a/api/sentry/utils.py
+++ b/api/sentry/utils.py
@@ -384,7 +384,14 @@ def main_unhandled_issues(
         f"&query=error.unhandled%3Atrue%20is%3Aunresolved"
         f"&environment={environment}&sort=freq&statsPeriod=7d"
     )
-    title_suffix = " (Detailed)" if longform else ""
+
+    if longform:
+        _write_longform_threaded(
+            rows, project, icon, product, now,
+            sentry_issues_url, project_id, environment,
+        )
+        return
+
     json_data = {
         "blocks": [
             {
@@ -393,74 +400,118 @@ def main_unhandled_issues(
                     "type": "mrkdwn",
                     "text": (
                         f"*:sentry: {icon} {product} "
-                        f"<{sentry_issues_url}|Top Sentry Issues>"
-                        f"{title_suffix} ({now})*"
+                        f"<{sentry_issues_url}|Top Sentry Issues> ({now})*"
                     )
                 }
             }
         ]
     }
 
-    if longform:
-        rows_by_version = {}
-        for row in rows:
-            version = row.get('release_version', '')
-            rows_by_version.setdefault(version, []).append(row)
+    rows_by_major = {}
+    for row in rows:
+        version = row.get('release_version', '')
+        try:
+            major = Version(version).major
+        except Exception:
+            continue
+        rows_by_major.setdefault(major, []).append(row)
 
-        if not rows_by_version:
-            insert_unhandled_issues(json_data, [])
-        else:
-            versions = sorted(rows_by_version.keys(), key=Version, reverse=True)
-            for version in versions:
-                version_url = (
-                    f"https://mozilla.sentry.io/issues/?limit=5"
-                    f"&project={project_id}"
-                    f"&query=error.unhandled%3Atrue%20is%3Aunresolved"
-                    f"%20release.version%3A{version}"
-                    f"&environment={environment}&sort=freq&statsPeriod=7d"
-                )
-                insert_unhandled_issues(
-                    json_data,
-                    rows_by_version[version],
-                    version=version,
-                    version_url=version_url,
-                )
+    if not rows_by_major:
+        insert_unhandled_issues(json_data, [])
     else:
-        rows_by_major = {}
-        for row in rows:
-            version = row.get('release_version', '')
-            try:
-                major = Version(version).major
-            except Exception:
-                continue
-            rows_by_major.setdefault(major, []).append(row)
-
-        if not rows_by_major:
-            insert_unhandled_issues(json_data, [])
-        else:
-            majors = sorted(rows_by_major.keys(), reverse=True)[:2]
-            for major in majors:
-                version_url = (
-                    f"https://mozilla.sentry.io/issues/?limit=5"
-                    f"&project={project_id}"
-                    f"&query=error.unhandled%3Atrue%20is%3Aunresolved"
-                    f"%20release.version%3A{major}.*"
-                    f"&environment={environment}&sort=freq&statsPeriod=7d"
-                )
-                insert_unhandled_issues(
-                    json_data,
-                    rows_by_major[major],
-                    version=str(major),
-                    version_url=version_url,
-                    limit=1,
-                )
+        majors = sorted(rows_by_major.keys(), reverse=True)[:2]
+        for major in majors:
+            version_url = (
+                f"https://mozilla.sentry.io/issues/?limit=5"
+                f"&project={project_id}"
+                f"&query=error.unhandled%3Atrue%20is%3Aunresolved"
+                f"%20release.version%3A{major}.*"
+                f"&environment={environment}&sort=freq&statsPeriod=7d"
+            )
+            insert_unhandled_issues(
+                json_data,
+                rows_by_major[major],
+                version=str(major),
+                version_url=version_url,
+                limit=1,
+            )
 
     insert_json_footer(json_data)
 
-    suffix = '-long' if longform else ''
-    output_path = Path(f'sentry-slack-unhandled{suffix}-{project}.json')
+    output_path = Path(f'sentry-slack-unhandled-{project}.json')
     output_path.write_text(json.dumps(json_data, indent=4))
     print(f"Slack message written to {output_path.resolve()}")
+
+
+def _write_longform_threaded(
+    rows, project, icon, product, now,
+    sentry_issues_url, project_id, environment,
+):
+    """Long-form report posted as a Slack thread.
+
+    Writes a header payload plus one reply payload per dot version. The
+    workflow posts the header with chat.postMessage, captures its `ts`, and
+    posts each reply with `thread_ts` set to that value.
+    """
+    header_text = (
+        f":sentry: {icon} {product} Top Sentry Issues "
+        f"(Detailed) ({now})"
+    )
+    header_block_text = (
+        f"*:sentry: {icon} {product} "
+        f"<{sentry_issues_url}|Top Sentry Issues> (Detailed) ({now})* "
+        f":thread:"
+    )
+    header_data = {
+        "text": header_text,
+        "blocks": [
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": header_block_text,
+                },
+            }
+        ],
+    }
+    header_path = Path(
+        f'sentry-slack-unhandled-long-{project}-header.json'
+    )
+    header_path.write_text(json.dumps(header_data, indent=4))
+    print(f"Slack header written to {header_path.resolve()}")
+
+    rows_by_version = {}
+    for row in rows:
+        version = row.get('release_version', '')
+        rows_by_version.setdefault(version, []).append(row)
+
+    if not rows_by_version:
+        return
+
+    versions = sorted(rows_by_version.keys(), key=Version, reverse=True)
+    for i, version in enumerate(versions, start=1):
+        version_url = (
+            f"https://mozilla.sentry.io/issues/?limit=5"
+            f"&project={project_id}"
+            f"&query=error.unhandled%3Atrue%20is%3Aunresolved"
+            f"%20release.version%3A{version}"
+            f"&environment={environment}&sort=freq&statsPeriod=7d"
+        )
+        reply_data = {
+            "text": f"v{version}",
+            "blocks": [],
+        }
+        insert_unhandled_issues(
+            reply_data,
+            rows_by_version[version],
+            version=version,
+            version_url=version_url,
+        )
+        reply_path = Path(
+            f'sentry-slack-unhandled-long-{project}-reply-{i:02d}.json'
+        )
+        reply_path.write_text(json.dumps(reply_data, indent=4))
+        print(f"Slack reply written to {reply_path.resolve()}")
 
 
 def main(file_csv: str, project: str, shortform: bool = False) -> None:

--- a/handlers/sentry.py
+++ b/handlers/sentry.py
@@ -13,4 +13,4 @@ def handle_sentry_rates(args):
 
 def handle_sentry_unhandled_issues(args):
     client = SentryClient(project=args.project)
-    client.sentry_unhandled_issues()
+    client.sentry_unhandled_issues(longform=getattr(args, 'longform', False))


### PR DESCRIPTION
We now have a long version and a short version of the Sentry issues Slack notification.

The long version lists the top issues affecting each dot releases from the last 2 major versions
https://mozilla.slack.com/archives/C0AM29C4AUE/p1779901701128009
<img width="500"  alt="Screenshot 2026-05-27 at 13 33 00" src="https://github.com/user-attachments/assets/f63ed6a0-e77a-414f-a927-2e4bdfe05460" />


The short version lists the top issues affecting the last 2 major versions (v151.x, v150.x etc). This version is intended to be embedded in the weekly product deepdive thread.
https://mozilla.slack.com/archives/C016BC5FUHJ/p1779901680825339
<img width="500" alt="Screenshot 2026-05-27 at 13 32 27" src="https://github.com/user-attachments/assets/e87f74f4-8a86-4263-94ea-9313bfd49e85" />

The long version is sent to #mobile-testeng-sandbox-sentry and the short version is sent to #mobile-alerts-sandbox.
