### PR TITLE
Bugfix MTE-4764 Fix ordering for long form report

### DIFF
--- a/api/sentry/utils.py
+++ b/api/sentry/utils.py
@@ -305,7 +305,8 @@ def _create_table_link_cell(text, url):
 
 
 def insert_unhandled_issues(
-    json_data, rows, version=None, version_url=None, limit=None
+    json_data, rows, version=None, version_url=None, limit=None,
+    sort_by_volume=False,
 ):
     if version is not None:
         header_text = (
@@ -326,6 +327,13 @@ def insert_unhandled_issues(
         row for row in rows
         if int(row['user_count']) > 1000 or int(row['count']) > 1000
     ]
+    # The detailed report orders each version's issues by events, then
+    # users affected (both descending), rather than Sentry's 7d freq order.
+    if sort_by_volume:
+        significant.sort(
+            key=lambda row: (int(row['count']), int(row['user_count'])),
+            reverse=True,
+        )
     if limit is not None:
         significant = significant[:limit]
     if not significant:
@@ -506,6 +514,7 @@ def _write_longform_threaded(
             rows_by_version[version],
             version=version,
             version_url=version_url,
+            sort_by_volume=True,
         )
         reply_path = Path(
             f'sentry-slack-unhandled-long-{project}-reply-{i:02d}.json'


### PR DESCRIPTION
The issues for v151.1 and v151.0's seem to be out of order just by looking at the table alone.  

<img width="812" height="737" alt="Screenshot 2026-06-02 at 13 43 04" src="https://github.com/user-attachments/assets/d3b20a4d-3aa9-45af-b748-a0bf0b5a8a79" />

The order was taking from Sentry's `sort=freq` 7-day order for all versions and not specific versions. This PR orders the issues for the specific versions:

<img width="835" height="890" alt="Screenshot 2026-06-02 at 13 57 42" src="https://github.com/user-attachments/assets/e21480d8-5194-430b-b73c-38ed2bda3f3a" />


The report above ☝🏼 was generated by this workflow run: https://github.com/mozilla-mobile/testops-dashboard/actions/runs/26837699159