### PR TITLE
Fix crash on non-list TestRail API response & Sentry non-JSON responses (#355)

### DIFF
--- a/api/sentry/api_sentry.py
+++ b/api/sentry/api_sentry.py
@@ -392,7 +392,7 @@ class DatabaseSentry:
     def report_issue_payload(self, issues, release_version):
         payload = []
         MAX_STRING_LEN = 250
-        for issue in issues:
+        for issue in issues or []:
             sentry_id = issue['id']
             culprit = issue['culprit']
             title = issue['title'][:MAX_STRING_LEN]

--- a/api/testrail/report_test_plans_and_runs.py
+++ b/api/testrail/report_test_plans_and_runs.py
@@ -174,6 +174,9 @@ def testrail_runs_update(project_plans, start_date=None, end_date=None, num_days
             start_date_value,
             end_date_value
         )
+        if not isinstance(plan_info, dict) or 'entries' not in plan_info:
+            print(f"No 'entries' for plan {plan['plan_id']}: {plan_info}")
+            continue
         for entry in plan_info['entries']:
             report_test_runs_insert(
                 plan['id'], entry['suite_id'], entry['runs'])

--- a/lib/sentry_conn.py
+++ b/lib/sentry_conn.py
@@ -5,7 +5,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import requests
-from requests.exceptions import HTTPError
+from requests.exceptions import HTTPError, JSONDecodeError
 
 
 class APIClient:
@@ -35,7 +35,14 @@ class APIClient:
             except HTTPError:
                 return None
 
-            data = response.json()
+            try:
+                data = response.json()
+            except JSONDecodeError:
+                # 2xx/3xx response with a non-JSON body (e.g. an HTML
+                # login/error page). Match the HTTPError path and bail.
+                print(f"Non-JSON response from {url}: {response.text[:200]!r}")
+                return None
+
             if isinstance(data, list):
                 all_results.extend(data)
                 print(f"Received {len(all_results)} items")

--- a/lib/testrail_conn.py
+++ b/lib/testrail_conn.py
@@ -87,9 +87,13 @@ class APIClient:
                 response = requests.get(f"{url}&limit={limit}&offset={offset}", headers=headers)
                 data = response.json()
 
-                # Check if 'cases' or 'milestones' key exists in the response
-                if isinstance(data, dict) and data_type in data:
-                    all_items.extend(data[data_type])  # Append cases or milestones
+                if data_type is None:
+                    # No collection key expected — caller wants the raw
+                    # response (e.g. a single plan/case object).
+                    all_items = data
+                    break
+                elif isinstance(data, dict) and data_type in data:
+                    all_items.extend(data[data_type])  # Append cases/milestones
 
                     if len(data[data_type]) < limit:
                         break

--- a/lib/testrail_conn.py
+++ b/lib/testrail_conn.py
@@ -88,15 +88,21 @@ class APIClient:
                 data = response.json()
 
                 # Check if 'cases' or 'milestones' key exists in the response
-                if data_type in data:
-                    print(data[data_type])
+                if isinstance(data, dict) and data_type in data:
                     all_items.extend(data[data_type])  # Append cases or milestones
 
                     if len(data[data_type]) < limit:
                         break
+                elif isinstance(data, list):
+                    all_items = data  # Legacy (non-paginated) list response
+                    break
                 else:
-                    all_items = data
-                    break  # If 'cases' key is not present, exit the loop
+                    # Unexpected/error response (e.g. {"error": ...}) — the
+                    # expected key is missing. Don't leak the dict downstream;
+                    # callers expect a list.
+                    print(f"Unexpected response for '{data_type}': {data}")
+                    all_items = []
+                    break
 
                 offset += limit
 


### PR DESCRIPTION
Fixes #355 

tl;dr fail gracefully instead of crashing when an API returns an unexpected response, e.g, a non-list/error payload from TestRail (test case coverage), a test plan with no entries, or a non-JSON body from Sentry (issues) by skipping and logging the bad data rather than letting the whole run die