### PR TITLE
Refactor MTE-4764 Fetch top new issues

### DIFF
--- a/api/sentry/api_sentry.py
+++ b/api/sentry/api_sentry.py
@@ -23,10 +23,6 @@ from database import (
 # The 2 major versions are beta and release.
 NUM_MAJOR_VERSIONS = 2
 
-# Notifications report issues in these unresolved substatuses, matching the
-# "New" and "Escalating" badges in Sentry's release issue list.
-NEW_ISSUE_SUBSTATUSES = ('new', 'escalating')
-
 # Notifications query this many of the most recent dot releases.
 NUM_DOT_RELEASES = 2
 
@@ -119,14 +115,14 @@ class Sentry:
             'https://whattrainisitnow.com/api/firefox/releases/esr/future/')
         return list(response.json().keys())
 
-    # API: Top issues for a release sorted by frequency over the past 7 days.
-    # Optionally restrict to an unresolved substatus (e.g. new, escalating).
-    def unhandled_issues(self, limit=5, release_version=None, substatus=None):
+    # API: Top unresolved issues first seen in a given release, sorted by
+    # frequency over the past 7 days. Matches Sentry's release "New Issues"
+    # tab, which includes both the "new" and "escalating" substatuses.
+    # first_release is the URL-encoded "<package>%40<version>" value.
+    def unhandled_issues(self, limit=5, first_release=None):
         query = 'is%3Aunresolved'
-        if substatus:
-            query += '%20is%3A' + substatus
-        if release_version:
-            query += '%20release.version%3A' + release_version
+        if first_release:
+            query += '%20firstRelease%3A' + first_release
         return self.client.http_get(
             (
                 'organizations/{0}/issues/'
@@ -262,35 +258,24 @@ class SentryClient(Sentry):
 
         for query_version, stored_version in queries:
             print(f"Filtering by release: {query_version}")
-            # Union the "new" and "escalating" substatuses for this dot
-            # release, de-duped by issue id (an issue can match only one
-            # substatus, but query separately since Sentry search can't OR
-            # them reliably).
-            by_id = {}
-            for substatus in NEW_ISSUE_SUBSTATUSES:
-                for issue in (
-                    self.unhandled_issues(
-                        limit=fetch_limit,
-                        release_version=query_version,
-                        substatus=substatus,
-                    )
-                    or []
-                ):
-                    by_id.setdefault(issue['id'], issue)
-            # Drop excluded titles, then rank by event volume so the Slack
-            # formatter's >500 threshold + top-3 selection surfaces the
-            # highest-impact issues. (The freq sort from each query no longer
-            # holds once two queries are merged.)
+            first_release = f"{self.package}%40{query_version}"
+            raw_issues = (
+                self.unhandled_issues(
+                    limit=fetch_limit,
+                    first_release=first_release,
+                )
+                or []
+            )
+            # Keep all candidates (already freq-sorted) after the exclusion
+            # list; the Slack formatter applies the >500 threshold before
+            # selecting the top 3 per dot release.
             issues = [
-                issue for issue in by_id.values()
+                issue for issue in raw_issues
                 if not any(
                     excl.lower() in issue['title'].lower()
                     for excl in self.excluded_issue_titles
                 )
             ]
-            issues.sort(
-                key=lambda i: int(i.get('count', 0) or 0), reverse=True
-            )
             for issue in issues:
                 payload.append([
                     issue['id'],

--- a/api/sentry/api_sentry.py
+++ b/api/sentry/api_sentry.py
@@ -26,6 +26,11 @@ NUM_MAJOR_VERSIONS = 2
 # Notifications query this many of the most recent dot releases.
 NUM_DOT_RELEASES = 2
 
+# Minimum user-adoption percentage for a release to count as "live". Releases
+# registered in Sentry but not yet shipped sit near 0% and are skipped. Matches
+# the crash-free-rate report's threshold in api/sentry/utils.py insert_rates.
+MIN_ADOPTION_RATE = 1
+
 
 class Sentry:
 
@@ -99,7 +104,7 @@ class Sentry:
         return self.client.http_get(
             (
                 '/organizations/mozilla/releases/'
-                '?adoptionStages=1&project={1}&environment={0}'
+                '?adoptionStages=1&project={1}&environment={0}&health=1'
                 '&query=release.package:{2}&status=open&summaryStatsPeriod=7d'
                 '&adoptionStages=1&sort=adoption'
             ).format(self.environment, self.sentry_project_id, self.package)
@@ -228,16 +233,65 @@ class SentryClient(Sentry):
         # Insert into database
         self.db.issue_insert(df_issues)
 
+    def _adopted_dot_releases(self, n):
+        """Return the newest n dot-release versions (e.g. 151.3) whose user
+        adoption exceeds MIN_ADOPTION_RATE percent.
+
+        Releases are registered in Sentry as soon as a build is uploaded, so
+        the highest version number is often a not-yet-shipped build sitting
+        near 0% adoption. Filtering by adoption keeps the actually-live
+        release(s) instead of those future builds.
+        """
+        releases = self.releases()
+        if not releases:
+            return []
+        latest = self.get_latest_train_release()[-1]
+        # Map raw version -> adoption percent from the same (health=1) response.
+        adoption = {}
+        for release in releases:
+            try:
+                raw = release['versionInfo']['version']['raw']
+            except (KeyError, TypeError):
+                continue
+            projects = release.get('projects') or []
+            match = next(
+                (p for p in projects
+                 if str(p.get('id')) == str(self.sentry_project_id)),
+                projects[0] if projects else None,
+            )
+            health = (match or {}).get('healthData') or {}
+            adoption[raw] = float(health.get('adoption', 0) or 0)
+        selected = []
+        seen = set()
+        for raw in self._report_version_strings(releases, latest):
+            dot = raw.split('+')[0]
+            if dot in seen:
+                continue
+            seen.add(dot)
+            rate = adoption.get(raw, 0.0)
+            if rate > MIN_ADOPTION_RATE:
+                print(f"Live release {dot}: adoption {rate}%")
+                selected.append(dot)
+            else:
+                print(f"Skipping low-adoption release {dot}: {rate}%")
+            if len(selected) >= n:
+                break
+        return selected
+
     def sentry_unhandled_issues(self, limit=3, longform=False):
         print(f"SentryClient.sentry_unhandled_issues(longform={longform})")
         if self.sentry_project == 'fenix-beta':
-            release_versions = [self.get_future_train_release()[0]]
+            # Beta is intentionally low-adoption; use the upcoming train
+            # release rather than filtering on adoption.
+            dot_releases = [
+                self.get_future_train_release()[0].split('+')[0]
+            ][:NUM_DOT_RELEASES]
         else:
-            release_versions = self.sentry_releases()
-            if not release_versions:
+            dot_releases = self._adopted_dot_releases(NUM_DOT_RELEASES)
+            if not dot_releases:
                 print(
-                    f"Warning: No releases found for '{self.sentry_project}', "
-                    "skipping."
+                    f"Warning: No live (adopted) releases found for "
+                    f"'{self.sentry_project}', skipping."
                 )
                 return
 
@@ -245,16 +299,7 @@ class SentryClient(Sentry):
         MAX_STRING_LEN = 250
         payload = []
 
-        # Both report forms cover the most recent dot releases (exact
-        # versions, e.g. 151.0.1). release_versions is already sorted
-        # newest-first, so take the first NUM_DOT_RELEASES distinct
-        # sub-versions.
-        dot_releases = []
-        for rv in release_versions:
-            version = rv.split('+')[0]
-            if version not in dot_releases:
-                dot_releases.append(version)
-        queries = [(v, v) for v in dot_releases[:NUM_DOT_RELEASES]]
+        queries = [(v, v) for v in dot_releases]
 
         for query_version, stored_version in queries:
             print(f"Filtering by release: {query_version}")

--- a/api/sentry/api_sentry.py
+++ b/api/sentry/api_sentry.py
@@ -23,6 +23,13 @@ from database import (
 # The 2 major versions are beta and release.
 NUM_MAJOR_VERSIONS = 2
 
+# Short-form notifications only report issues first seen within this window.
+# Sentry date-field syntax: "-7d" means "within the last 7 days".
+NEW_ISSUE_WINDOW = '-7d'
+
+# Short-form notifications query this many of the most recent dot releases.
+NUM_DOT_RELEASES = 2
+
 
 class Sentry:
 
@@ -113,12 +120,14 @@ class Sentry:
         return list(response.json().keys())
 
     # API: Top unhandled issues sorted by frequency over the past 7 days
-    def unhandled_issues(self, limit=5, release_version=None):
+    def unhandled_issues(self, limit=5, release_version=None, new_only=False):
         query = (
             'error.unhandled%3Atrue%20is%3Aunresolved'
         )
         if release_version:
             query += '%20release.version%3A' + release_version
+        if new_only:
+            query += '%20firstSeen%3A' + NEW_ISSUE_WINDOW
         return self.client.http_get(
             (
                 'organizations/{0}/issues/'
@@ -241,22 +250,16 @@ class SentryClient(Sentry):
         MAX_STRING_LEN = 250
         payload = []
 
-        if longform:
-            # Top N issues per exact sub-version (e.g. 151.0, 151.0.1).
-            queries = [
-                (rv.split('+')[0], rv.split('+')[0])
-                for rv in release_versions
-            ]
-        else:
-            # Top issue per major version using a wildcard query so the
-            # result matches Sentry's UI for release.version:<major>.* —
-            # otherwise an issue whose events are spread across multiple
-            # sub-versions ranks low in every per-sub-version query.
-            majors = sorted({
-                int(rv.split('+')[0].split('.')[0])
-                for rv in release_versions
-            }, reverse=True)
-            queries = [(f"{m}.*", str(m)) for m in majors]
+        # Both report forms cover the most recent dot releases (exact
+        # versions, e.g. 151.0.1), restricted to new issues. release_versions
+        # is already sorted newest-first, so take the first NUM_DOT_RELEASES
+        # distinct sub-versions.
+        dot_releases = []
+        for rv in release_versions:
+            version = rv.split('+')[0]
+            if version not in dot_releases:
+                dot_releases.append(version)
+        queries = [(v, v) for v in dot_releases[:NUM_DOT_RELEASES]]
 
         for query_version, stored_version in queries:
             print(f"Filtering by release: {query_version}")
@@ -264,16 +267,20 @@ class SentryClient(Sentry):
                 self.unhandled_issues(
                     limit=fetch_limit,
                     release_version=query_version,
+                    new_only=True,
                 )
                 or []
             )
+            # Keep all candidates after the exclusion list; the Slack
+            # formatter applies the >500 threshold before selecting the top 3
+            # per dot release.
             issues = [
                 issue for issue in raw_issues
                 if not any(
                     excl.lower() in issue['title'].lower()
                     for excl in self.excluded_issue_titles
                 )
-            ][:limit]
+            ]
             for issue in issues:
                 payload.append([
                     issue['id'],

--- a/api/sentry/api_sentry.py
+++ b/api/sentry/api_sentry.py
@@ -23,11 +23,11 @@ from database import (
 # The 2 major versions are beta and release.
 NUM_MAJOR_VERSIONS = 2
 
-# Short-form notifications only report issues first seen within this window.
-# Sentry date-field syntax: "-7d" means "within the last 7 days".
-NEW_ISSUE_WINDOW = '-7d'
+# Notifications report issues in these unresolved substatuses, matching the
+# "New" and "Escalating" badges in Sentry's release issue list.
+NEW_ISSUE_SUBSTATUSES = ('new', 'escalating')
 
-# Short-form notifications query this many of the most recent dot releases.
+# Notifications query this many of the most recent dot releases.
 NUM_DOT_RELEASES = 2
 
 
@@ -119,15 +119,14 @@ class Sentry:
             'https://whattrainisitnow.com/api/firefox/releases/esr/future/')
         return list(response.json().keys())
 
-    # API: Top unhandled issues sorted by frequency over the past 7 days
-    def unhandled_issues(self, limit=5, release_version=None, new_only=False):
-        query = (
-            'error.unhandled%3Atrue%20is%3Aunresolved'
-        )
+    # API: Top issues for a release sorted by frequency over the past 7 days.
+    # Optionally restrict to an unresolved substatus (e.g. new, escalating).
+    def unhandled_issues(self, limit=5, release_version=None, substatus=None):
+        query = 'is%3Aunresolved'
+        if substatus:
+            query += '%20is%3A' + substatus
         if release_version:
             query += '%20release.version%3A' + release_version
-        if new_only:
-            query += '%20firstSeen%3A' + NEW_ISSUE_WINDOW
         return self.client.http_get(
             (
                 'organizations/{0}/issues/'
@@ -251,9 +250,9 @@ class SentryClient(Sentry):
         payload = []
 
         # Both report forms cover the most recent dot releases (exact
-        # versions, e.g. 151.0.1), restricted to new issues. release_versions
-        # is already sorted newest-first, so take the first NUM_DOT_RELEASES
-        # distinct sub-versions.
+        # versions, e.g. 151.0.1). release_versions is already sorted
+        # newest-first, so take the first NUM_DOT_RELEASES distinct
+        # sub-versions.
         dot_releases = []
         for rv in release_versions:
             version = rv.split('+')[0]
@@ -263,24 +262,35 @@ class SentryClient(Sentry):
 
         for query_version, stored_version in queries:
             print(f"Filtering by release: {query_version}")
-            raw_issues = (
-                self.unhandled_issues(
-                    limit=fetch_limit,
-                    release_version=query_version,
-                    new_only=True,
-                )
-                or []
-            )
-            # Keep all candidates after the exclusion list; the Slack
-            # formatter applies the >500 threshold before selecting the top 3
-            # per dot release.
+            # Union the "new" and "escalating" substatuses for this dot
+            # release, de-duped by issue id (an issue can match only one
+            # substatus, but query separately since Sentry search can't OR
+            # them reliably).
+            by_id = {}
+            for substatus in NEW_ISSUE_SUBSTATUSES:
+                for issue in (
+                    self.unhandled_issues(
+                        limit=fetch_limit,
+                        release_version=query_version,
+                        substatus=substatus,
+                    )
+                    or []
+                ):
+                    by_id.setdefault(issue['id'], issue)
+            # Drop excluded titles, then rank by event volume so the Slack
+            # formatter's >500 threshold + top-3 selection surfaces the
+            # highest-impact issues. (The freq sort from each query no longer
+            # holds once two queries are merged.)
             issues = [
-                issue for issue in raw_issues
+                issue for issue in by_id.values()
                 if not any(
                     excl.lower() in issue['title'].lower()
                     for excl in self.excluded_issue_titles
                 )
             ]
+            issues.sort(
+                key=lambda i: int(i.get('count', 0) or 0), reverse=True
+            )
             for issue in issues:
                 payload.append([
                     issue['id'],

--- a/api/sentry/utils.py
+++ b/api/sentry/utils.py
@@ -41,6 +41,33 @@ def format_count(value) -> str:
     return f"{round(n / 1000)}k"
 
 
+def package_for(project: str) -> str:
+    """Parse the app package (e.g. org.mozilla.ios.Firefox) from the Sentry
+    config's query string (`release.package:<package>`)."""
+    query = (
+        project_config.get(project, {}).get('sentry', {})
+        .get('params', {}).get('query', '')
+    )
+    marker = 'release.package:'
+    if marker in query:
+        return query.split(marker, 1)[1].strip()
+    return ''
+
+
+def first_release_url(project_id, environment, package, version=None) -> str:
+    """Build a Sentry issue-list URL for new issues, matching the query used
+    to fetch them: unresolved issues first seen in the given release. When a
+    version is provided, scope to `firstRelease:<package>@<version>`."""
+    query = "is%3Aunresolved"
+    if version and package:
+        query += f"%20firstRelease%3A{package}%40{version}"
+    return (
+        f"https://mozilla.sentry.io/issues/?limit=5&project={project_id}"
+        f"&query={query}"
+        f"&environment={environment}&sort=freq&statsPeriod=7d"
+    )
+
+
 def get_all_future_versions():
     response = requests.get('https://whattrainisitnow.com/api/firefox/releases/future/')
     if response.status_code != 200:
@@ -407,18 +434,27 @@ def main_unhandled_issues(
     sentry_params = project_config.get(project, {}).get('sentry', {}).get('params', {})
     project_id = sentry_params.get('project', '')
     environment = sentry_params.get('environment', '')
-    # Both report forms surface new/escalating unresolved issues; the header
-    # link lands on the release's unresolved issues (New/Escalating badged).
-    sentry_issues_url = (
-        f"https://mozilla.sentry.io/issues/?limit=5&project={project_id}"
-        f"&query=is%3Aunresolved"
-        f"&environment={environment}&sort=freq&statsPeriod=7d"
+    package = package_for(project)
+
+    # Group by exact dot release (e.g. 151.0.1) and report the most recent
+    # two, showing up to 3 significant new issues each.
+    rows_by_version = {}
+    for row in rows:
+        version = row.get('release_version', '')
+        rows_by_version.setdefault(version, []).append(row)
+    versions = sorted(rows_by_version.keys(), key=Version, reverse=True)[:2]
+
+    # The header link uses the same firstRelease query as the latest
+    # version's link, so both land on the same set of new issues.
+    latest_version = versions[0] if versions else None
+    sentry_issues_url = first_release_url(
+        project_id, environment, package, latest_version
     )
 
     if longform:
         _write_longform_threaded(
             rows, project, icon, product, now,
-            sentry_issues_url, project_id, environment,
+            sentry_issues_url, project_id, environment, package,
         )
         return
 
@@ -438,28 +474,14 @@ def main_unhandled_issues(
         ]
     }
 
-    # Group by exact dot release (e.g. 151.0.1) and report the most recent
-    # two, showing up to 3 significant new issues each.
-    rows_by_version = {}
-    for row in rows:
-        version = row.get('release_version', '')
-        rows_by_version.setdefault(version, []).append(row)
-
-    if not rows_by_version:
+    if not versions:
         insert_unhandled_issues(
             json_data, [], threshold=500, humanize_counts=True
         )
     else:
-        versions = sorted(
-            rows_by_version.keys(), key=Version, reverse=True
-        )[:2]
         for version in versions:
-            version_url = (
-                f"https://mozilla.sentry.io/issues/?limit=5"
-                f"&project={project_id}"
-                f"&query=is%3Aunresolved"
-                f"%20release.version%3A{version}"
-                f"&environment={environment}&sort=freq&statsPeriod=7d"
+            version_url = first_release_url(
+                project_id, environment, package, version
             )
             insert_unhandled_issues(
                 json_data,
@@ -480,7 +502,7 @@ def main_unhandled_issues(
 
 def _write_longform_threaded(
     rows, project, icon, product, now,
-    sentry_issues_url, project_id, environment,
+    sentry_issues_url, project_id, environment, package,
 ):
     """Long-form report posted as a Slack thread.
 
@@ -528,12 +550,8 @@ def _write_longform_threaded(
         rows_by_version.keys(), key=Version, reverse=True
     )[:2]
     for i, version in enumerate(versions, start=1):
-        version_url = (
-            f"https://mozilla.sentry.io/issues/?limit=5"
-            f"&project={project_id}"
-            f"&query=is%3Aunresolved"
-            f"%20release.version%3A{version}"
-            f"&environment={environment}&sort=freq&statsPeriod=7d"
+        version_url = first_release_url(
+            project_id, environment, package, version
         )
         reply_data = {
             "text": f"v{version}",

--- a/api/sentry/utils.py
+++ b/api/sentry/utils.py
@@ -458,8 +458,7 @@ def main_unhandled_issues(
                 "text": {
                     "type": "mrkdwn",
                     "text": (
-                        f"*:sentry: {icon} {product} "
-                        f"Top New Sentry Issues "
+                        f"*:sentry: Top New Sentry Issues "
                         f"({now})*"
                     )
                 }
@@ -485,8 +484,6 @@ def main_unhandled_issues(
                 threshold=500,
                 humanize_counts=True,
             )
-
-    insert_json_footer(json_data)
 
     output_path = Path(f'sentry-slack-unhandled-{project}.json')
     output_path.write_text(json.dumps(json_data, indent=4))
@@ -560,6 +557,9 @@ def _write_longform_threaded(
             threshold=500,
             humanize_counts=True,
         )
+        # Footer goes on the last reply so it closes out the thread.
+        if i == len(versions):
+            insert_json_footer(reply_data)
         reply_path = Path(
             f'sentry-slack-unhandled-long-{project}-reply-{i:02d}.json'
         )

--- a/api/sentry/utils.py
+++ b/api/sentry/utils.py
@@ -29,6 +29,18 @@ def build_url(base_url: str, params: dict | None = None) -> str:
     return f"{base_url}?{urlencode(params)}"
 
 
+def format_count(value) -> str:
+    """Render a count compactly in thousands (e.g. 5343 -> "5k").
+
+    Values below 1000 are shown as-is to avoid misleading rounding
+    (e.g. 600 -> "600", not "1k").
+    """
+    n = int(value)
+    if n < 1000:
+        return str(n)
+    return f"{round(n / 1000)}k"
+
+
 def get_all_future_versions():
     response = requests.get('https://whattrainisitnow.com/api/firefox/releases/future/')
     if response.status_code != 200:
@@ -306,7 +318,7 @@ def _create_table_link_cell(text, url):
 
 def insert_unhandled_issues(
     json_data, rows, version=None, version_url=None, limit=None,
-    sort_by_volume=False,
+    sort_by_volume=False, threshold=1000, humanize_counts=False,
 ):
     if version is not None:
         header_text = (
@@ -325,7 +337,7 @@ def insert_unhandled_issues(
     # re-sorting would surface old high-volume issues over recent ones.
     significant = [
         row for row in rows
-        if int(row['user_count']) > 1000 or int(row['count']) > 1000
+        if int(row['user_count']) > threshold or int(row['count']) > threshold
     ]
     # The detailed report orders each version's issues by events, then
     # users affected (both descending), rather than Sentry's 7d freq order.
@@ -358,13 +370,21 @@ def insert_unhandled_issues(
         title = row['title']
         if len(title) > MAX_TITLE_DISPLAY_LEN:
             title = title[:MAX_TITLE_DISPLAY_LEN] + '…'
+        count_text = (
+            format_count(row['count']) if humanize_counts
+            else str(row['count'])
+        )
+        user_count_text = (
+            format_count(row['user_count']) if humanize_counts
+            else str(row['user_count'])
+        )
         table_rows.append([
             _create_table_link_cell(
                 row.get('short_id', ''), row['permalink']
             ),
             {"type": "raw_text", "text": title},
-            {"type": "raw_text", "text": str(row['count'])},
-            {"type": "raw_text", "text": str(row['user_count'])},
+            {"type": "raw_text", "text": count_text},
+            {"type": "raw_text", "text": user_count_text},
         ])
 
     json_data["blocks"].append({
@@ -387,9 +407,12 @@ def main_unhandled_issues(
     sentry_params = project_config.get(project, {}).get('sentry', {}).get('params', {})
     project_id = sentry_params.get('project', '')
     environment = sentry_params.get('environment', '')
+    # Both report forms only surface issues first seen in the last 7 days,
+    # so the header link carries the firstSeen filter inside the query param.
     sentry_issues_url = (
         f"https://mozilla.sentry.io/issues/?limit=5&project={project_id}"
         f"&query=error.unhandled%3Atrue%20is%3Aunresolved"
+        f"%20firstSeen%3A-7d"
         f"&environment={environment}&sort=freq&statsPeriod=7d"
     )
 
@@ -408,40 +431,45 @@ def main_unhandled_issues(
                     "type": "mrkdwn",
                     "text": (
                         f"*:sentry: {icon} {product} "
-                        f"<{sentry_issues_url}|Top Sentry Issues> ({now})*"
+                        f"<{sentry_issues_url}|Top New Sentry Issues> "
+                        f"({now})*"
                     )
                 }
             }
         ]
     }
 
-    rows_by_major = {}
+    # Group by exact dot release (e.g. 151.0.1) and report the most recent
+    # two, showing up to 3 significant new issues each.
+    rows_by_version = {}
     for row in rows:
         version = row.get('release_version', '')
-        try:
-            major = Version(version).major
-        except Exception:
-            continue
-        rows_by_major.setdefault(major, []).append(row)
+        rows_by_version.setdefault(version, []).append(row)
 
-    if not rows_by_major:
-        insert_unhandled_issues(json_data, [])
+    if not rows_by_version:
+        insert_unhandled_issues(
+            json_data, [], threshold=500, humanize_counts=True
+        )
     else:
-        majors = sorted(rows_by_major.keys(), reverse=True)[:2]
-        for major in majors:
+        versions = sorted(
+            rows_by_version.keys(), key=Version, reverse=True
+        )[:2]
+        for version in versions:
             version_url = (
                 f"https://mozilla.sentry.io/issues/?limit=5"
                 f"&project={project_id}"
                 f"&query=error.unhandled%3Atrue%20is%3Aunresolved"
-                f"%20release.version%3A{major}.*"
+                f"%20release.version%3A{version}%20firstSeen%3A-7d"
                 f"&environment={environment}&sort=freq&statsPeriod=7d"
             )
             insert_unhandled_issues(
                 json_data,
-                rows_by_major[major],
-                version=str(major),
+                rows_by_version[version],
+                version=version,
                 version_url=version_url,
-                limit=1,
+                limit=3,
+                threshold=500,
+                humanize_counts=True,
             )
 
     insert_json_footer(json_data)
@@ -462,12 +490,12 @@ def _write_longform_threaded(
     posts each reply with `thread_ts` set to that value.
     """
     header_text = (
-        f":sentry: {icon} {product} Top Sentry Issues "
+        f":sentry: {icon} {product} Top New Sentry Issues "
         f"(Detailed) ({now})"
     )
     header_block_text = (
         f"*:sentry: {icon} {product} "
-        f"<{sentry_issues_url}|Top Sentry Issues> (Detailed) ({now})* "
+        f"<{sentry_issues_url}|Top New Sentry Issues> (Detailed) ({now})* "
         f":thread:"
     )
     header_data = {
@@ -496,13 +524,16 @@ def _write_longform_threaded(
     if not rows_by_version:
         return
 
-    versions = sorted(rows_by_version.keys(), key=Version, reverse=True)
+    # Report the two most recent dot releases, newest first.
+    versions = sorted(
+        rows_by_version.keys(), key=Version, reverse=True
+    )[:2]
     for i, version in enumerate(versions, start=1):
         version_url = (
             f"https://mozilla.sentry.io/issues/?limit=5"
             f"&project={project_id}"
             f"&query=error.unhandled%3Atrue%20is%3Aunresolved"
-            f"%20release.version%3A{version}"
+            f"%20release.version%3A{version}%20firstSeen%3A-7d"
             f"&environment={environment}&sort=freq&statsPeriod=7d"
         )
         reply_data = {
@@ -514,7 +545,10 @@ def _write_longform_threaded(
             rows_by_version[version],
             version=version,
             version_url=version_url,
+            limit=3,
             sort_by_volume=True,
+            threshold=500,
+            humanize_counts=True,
         )
         reply_path = Path(
             f'sentry-slack-unhandled-long-{project}-reply-{i:02d}.json'

--- a/api/sentry/utils.py
+++ b/api/sentry/utils.py
@@ -407,12 +407,11 @@ def main_unhandled_issues(
     sentry_params = project_config.get(project, {}).get('sentry', {}).get('params', {})
     project_id = sentry_params.get('project', '')
     environment = sentry_params.get('environment', '')
-    # Both report forms only surface issues first seen in the last 7 days,
-    # so the header link carries the firstSeen filter inside the query param.
+    # Both report forms surface new/escalating unresolved issues; the header
+    # link lands on the release's unresolved issues (New/Escalating badged).
     sentry_issues_url = (
         f"https://mozilla.sentry.io/issues/?limit=5&project={project_id}"
-        f"&query=error.unhandled%3Atrue%20is%3Aunresolved"
-        f"%20firstSeen%3A-7d"
+        f"&query=is%3Aunresolved"
         f"&environment={environment}&sort=freq&statsPeriod=7d"
     )
 
@@ -458,8 +457,8 @@ def main_unhandled_issues(
             version_url = (
                 f"https://mozilla.sentry.io/issues/?limit=5"
                 f"&project={project_id}"
-                f"&query=error.unhandled%3Atrue%20is%3Aunresolved"
-                f"%20release.version%3A{version}%20firstSeen%3A-7d"
+                f"&query=is%3Aunresolved"
+                f"%20release.version%3A{version}"
                 f"&environment={environment}&sort=freq&statsPeriod=7d"
             )
             insert_unhandled_issues(
@@ -532,8 +531,8 @@ def _write_longform_threaded(
         version_url = (
             f"https://mozilla.sentry.io/issues/?limit=5"
             f"&project={project_id}"
-            f"&query=error.unhandled%3Atrue%20is%3Aunresolved"
-            f"%20release.version%3A{version}%20firstSeen%3A-7d"
+            f"&query=is%3Aunresolved"
+            f"%20release.version%3A{version}"
             f"&environment={environment}&sort=freq&statsPeriod=7d"
         )
         reply_data = {

--- a/api/sentry/utils.py
+++ b/api/sentry/utils.py
@@ -380,7 +380,7 @@ def insert_unhandled_issues(
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": ":white_check_mark: No significant issue to report."
+                "text": "No significant new issue to report."
             }
         })
         return json_data
@@ -444,17 +444,10 @@ def main_unhandled_issues(
         rows_by_version.setdefault(version, []).append(row)
     versions = sorted(rows_by_version.keys(), key=Version, reverse=True)[:2]
 
-    # The header link uses the same firstRelease query as the latest
-    # version's link, so both land on the same set of new issues.
-    latest_version = versions[0] if versions else None
-    sentry_issues_url = first_release_url(
-        project_id, environment, package, latest_version
-    )
-
     if longform:
         _write_longform_threaded(
             rows, project, icon, product, now,
-            sentry_issues_url, project_id, environment, package,
+            project_id, environment, package,
         )
         return
 
@@ -466,7 +459,7 @@ def main_unhandled_issues(
                     "type": "mrkdwn",
                     "text": (
                         f"*:sentry: {icon} {product} "
-                        f"<{sentry_issues_url}|Top New Sentry Issues> "
+                        f"Top New Sentry Issues "
                         f"({now})*"
                     )
                 }
@@ -502,7 +495,7 @@ def main_unhandled_issues(
 
 def _write_longform_threaded(
     rows, project, icon, product, now,
-    sentry_issues_url, project_id, environment, package,
+    project_id, environment, package,
 ):
     """Long-form report posted as a Slack thread.
 
@@ -516,7 +509,7 @@ def _write_longform_threaded(
     )
     header_block_text = (
         f"*:sentry: {icon} {product} "
-        f"<{sentry_issues_url}|Top New Sentry Issues> (Detailed) ({now})* "
+        f"Top New Sentry Issues (Detailed) ({now})* "
         f":thread:"
     )
     header_data = {


### PR DESCRIPTION
After the discussion with Winnie, I have implemented the following changes in the Sentry issue reporting:
* Query only the last two dot (instead of major) releases
* Report new and escalating *new* issues affecting more than 500 events/users
* Report top 3 reports in the long form report
* Abbreviate the number over 1000. Example: `2343` becomes `2k`.

In addition, I have updated the hyperlinks in the Slack notification to reflect the update.

Short form (to be in the weekly deepdive)
<img width="972" height="258" alt="Screenshot 2026-06-08 at 17 31 41" src="https://github.com/user-attachments/assets/c7a3104e-a39f-47a1-b806-7e5905ac1c0a" />
Long form (in sandbox only currently)
<img width="637" height="289" alt="Screenshot 2026-06-08 at 17 31 32" src="https://github.com/user-attachments/assets/07cda8db-92de-4899-baae-f42d858e2a43" />
