### PR TITLE
Add new column for TAE test coverage

### DIFF
--- a/api/testrail/report_test_case_coverage.py
+++ b/api/testrail/report_test_case_coverage.py
@@ -37,6 +37,23 @@ def _tr() -> TestRail():
     return _TR
 
 
+def _has_tae_label(labels):
+    """
+    Return 1 if the TestRail case's `labels` list contains the TAE label
+    (case-insensitive on the label's title/name), else 0.
+    """
+    if not isinstance(labels, list):
+        return 0
+    for lbl in labels:
+        if isinstance(lbl, dict):
+            name = lbl.get('title') or lbl.get('name') or ''
+        else:
+            name = str(lbl)
+        if name.strip().lower() == 'tae':
+            return 1
+    return 0
+
+
 # ===================================================================
 # ORCHESTRATOR (BATCH)
 # ===================================================================
@@ -127,20 +144,21 @@ def report_test_coverage_payload(cases):
 
         stat = case['custom_automation_status']
         cov = case['custom_automation_coverage']
+        tae = _has_tae_label(case.get('labels'))
 
         # iterate through multi-select sub_suite data
         # we need to create a separate row for each
         # test case that belongs to multiple sub suites
         for sub in subs:
-            row = [suit, sub, stat, cov, 1]
+            row = [suit, sub, stat, cov, tae, 1]
             payload.append(row)
 
     df = pd.DataFrame(
         data=payload,
-        columns=['suit', 'sub', 'status', 'cov', 'tally']
+        columns=['suit', 'sub', 'status', 'cov', 'tae', 'tally']
     )
     return (
-        df.groupby(['suit', 'sub', 'status', 'cov'])['tally']
+        df.groupby(['suit', 'sub', 'status', 'cov', 'tae'])['tally']
           .sum()
           .reset_index()
     )
@@ -203,6 +221,7 @@ def report_test_coverage_insert(projects_id, payload):
             test_automation_status_id=row['status'],
             test_automation_coverage_id=row['cov'],
             test_sub_suites_id=row['sub'],
+            test_automation_tae=row['tae'],
             test_count=row['tally']
         )
         db.session.add(report)

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -441,6 +441,7 @@ CREATE TABLE `report_test_case_coverage` (
   `test_sub_suites_id` int NOT NULL DEFAULT '1',
   `test_automation_status_id` int NOT NULL,
   `test_automation_coverage_id` int NOT NULL,
+  `test_automation_tae` int NOT NULL DEFAULT '0',
   `test_count` int NOT NULL DEFAULT '0',
   `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),


### PR DESCRIPTION
We are adding a new column to the `report_test_case_coverage` table to measure the number of automated tests using TAE framework.
TAE is added in testrail as a label for each test.

Things to consider after doing this change:

- Long running looker views and graphs that shows test coverage that use this table and could be affected
https://mozilla.cloud.looker.com/dashboards/601
- New looker view that should take this new column into account
https://mozilla.cloud.looker.com/dashboards/2750?tab_name=Conversion+Progress&Sunset+Verdict=
- Add this new column to `staging` and `production` databases