### PR TITLE
Fix DataError from emoji in GitHub issue titles

### DIFF
--- a/api/github/api_github.py
+++ b/api/github/api_github.py
@@ -4,6 +4,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import re
 import sys
 import requests
 from datetime import datetime, timedelta, UTC
@@ -17,6 +18,17 @@ from database import (
 from sqlalchemy.exc import IntegrityError
 
 import pandas as pd
+
+
+EMOJI_PATTERN = re.compile(
+    '[\U00010000-\U0010ffff]', flags=re.UNICODE
+)
+
+
+def sanitize_title(title):
+    if not title:
+        return title
+    return EMOJI_PATTERN.sub('', title).strip()
 
 
 API_BASE = 'https://api.github.com'
@@ -240,7 +252,9 @@ class GithubClient(Github):
         for bug in all_bugs:
             bug_data.append({
                 'github_number': bug.get('number', ''),
-                'github_title': bug.get('title', '(No title)'),
+                'github_title': sanitize_title(
+                    bug.get('title', '(No title)')
+                ),
                 'github_state': bug.get('state', ''),
                 'github_url': bug.get('html_url', ''),
                 'github_created_at': bug.get('created_at', ''),
@@ -365,7 +379,7 @@ class DatabaseGithub(Database):
 
         fmt = '%Y-%m-%dT%H:%M:%SZ'
 
-        record.github_title = issue_data.get('title')
+        record.github_title = sanitize_title(issue_data.get('title'))
         record.github_url = issue_data.get('html_url')
         record.github_state = issue_data.get('state')
         record.github_user = issue_data.get('user', {}).get('login')


### PR DESCRIPTION
## Summary
- Strips 4-byte UTF-8 characters (emojis) from GitHub issue titles before DB writes, fixing `DataError: Incorrect string value` on the `github_title` varchar column
- Applies sanitization at both ingestion paths: new bug collection (`GithubClient`) and issue updates (`DatabaseGithub.update_issue`)
- Root cause: [Weekly Health Monitoring Deep Dive failure](https://github.com/mozilla-mobile/testops-dashboard/actions/runs/28021432642/job/82938441643) from `🙏` in issue title `[feature request] export/import bookmarks on mobile device. 🙏`

## Test plan
- [ ] Verify weekly deepdive workflow passes on re-run
- [ ] Confirm issue titles with emojis are stored with emojis stripped
- [ ] Consider migrating `github_title` column to `utf8mb4` for long-term emoji support

🤖 Generated with [Claude Code](https://claude.com/claude-code)