### PR TITLE
Eliminate emojis in all values not only for github

### DIFF
--- a/api/github/api_github.py
+++ b/api/github/api_github.py
@@ -4,7 +4,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import re
 import sys
 import requests
 from datetime import datetime, timedelta, UTC
@@ -18,17 +17,6 @@ from database import (
 from sqlalchemy.exc import IntegrityError
 
 import pandas as pd
-
-
-EMOJI_PATTERN = re.compile(
-    '[\U00010000-\U0010ffff]', flags=re.UNICODE
-)
-
-
-def sanitize_title(title):
-    if not title:
-        return title
-    return EMOJI_PATTERN.sub('', title).strip()
 
 
 API_BASE = 'https://api.github.com'
@@ -252,9 +240,7 @@ class GithubClient(Github):
         for bug in all_bugs:
             bug_data.append({
                 'github_number': bug.get('number', ''),
-                'github_title': sanitize_title(
-                    bug.get('title', '(No title)')
-                ),
+                'github_title': bug.get('title', '(No title)'),
                 'github_state': bug.get('state', ''),
                 'github_url': bug.get('html_url', ''),
                 'github_created_at': bug.get('created_at', ''),
@@ -379,7 +365,7 @@ class DatabaseGithub(Database):
 
         fmt = '%Y-%m-%dT%H:%M:%SZ'
 
-        record.github_title = sanitize_title(issue_data.get('title'))
+        record.github_title = issue_data.get('title')
         record.github_url = issue_data.get('html_url')
         record.github_state = issue_data.get('state')
         record.github_user = issue_data.get('user', {}).get('login')

--- a/lib/database_conn.py
+++ b/lib/database_conn.py
@@ -8,10 +8,17 @@
 https://github.com/swaathi/sqlalchemy"""
 
 import os
+import re
 
-from sqlalchemy import create_engine, engine
+from sqlalchemy import create_engine, engine, event, String
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
+
+# MySQL utf8 columns only support 3-byte UTF-8. Characters in the
+# supplementary planes (emoji, rare CJK, etc.) are 4 bytes and cause
+# DataError on insert. Strip them at the session level so every model
+# is protected regardless of which API the data came from.
+_FOUR_BYTE_UTF8 = re.compile('[\U00010000-\U0010ffff]', flags=re.UNICODE)
 
 
 db_username = os.environ['CLOUD_SQL_DATABASE_USERNAME']
@@ -47,3 +54,16 @@ pool = create_engine(
 
 Session = sessionmaker(bind=pool)
 Base.metadata.bind = pool
+
+
+@event.listens_for(Session, 'before_flush')
+def _sanitize_string_values(session, flush_context, instances):
+    for obj in session.new | session.dirty:
+        mapper = getattr(obj.__class__, '__mapper__', None)
+        if mapper is None:
+            continue
+        for col in mapper.columns:
+            if isinstance(col.type, String):
+                val = getattr(obj, col.key, None)
+                if isinstance(val, str) and _FOUR_BYTE_UTF8.search(val):
+                    setattr(obj, col.key, _FOUR_BYTE_UTF8.sub('', val))


### PR DESCRIPTION
Follow up from the crash (See https://github.com/mozilla-mobile/testops-dashboard/pull/365), let's apply the fix for all sources of data. This solution remove all emojis that may not work with the database.

I've been running some jobs in the staging environment with the change from this branch:
https://github.com/mozilla-mobile/testops-dashboard/actions/runs/28075114978
https://github.com/mozilla-mobile/testops-dashboard/actions/runs/28075096942