### PR TITLE
Split Run charts by Smoke, L10n, and Functional

### DIFF
--- a/api/testrail/report_test_plans_and_runs.py
+++ b/api/testrail/report_test_plans_and_runs.py
@@ -233,6 +233,15 @@ def report_test_plans_insert(project_id, payload):
     return payload
 
 
+def _classify_run(name):
+    n = (name or '').upper()
+    if 'SMOKE' in n:
+        return 'Smoke'
+    if 'L10N' in n:
+        return 'L10n'
+    return 'Functional'
+
+
 def report_test_runs_insert(db_plan_id, suite_id, runs):
     db = _db()
 
@@ -256,6 +265,7 @@ def report_test_runs_insert(db_plan_id, suite_id, runs):
             suite_id=suite_id,
             name=run['name'],
             config=run.get('config') or '',
+            category=_classify_run(run['name']),
             test_case_passed_count=run['passed_count'],
             test_case_retest_count=run['retest_count'],
             test_case_failed_count=run['failed_count'],

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -585,6 +585,7 @@ CREATE TABLE `report_testrail_test_runs` (
   `suite_id` int NOT NULL,
   `name` varchar(75) NOT NULL,
   `config` varchar(55) NOT NULL,
+  `category` varchar(20) NOT NULL DEFAULT 'Functional',
   `test_case_passed_count` int NOT NULL DEFAULT '0',
   `test_case_retest_count` int NOT NULL DEFAULT '0',
   `test_case_failed_count` int NOT NULL DEFAULT '0',


### PR DESCRIPTION
## Summary
- Add a `category` column (`VARCHAR(20) NOT NULL DEFAULT 'Functional'`) to `report_testrail_test_runs`
- Classify each run on insert via `_classify_run()` — keyword match on the run name: `SMOKE` → `Smoke`, `L10N` → `L10n`, else `Functional`
- Lets Looker group the Run charts into three series (Smoke / L10n / Functional) instead of one

## Follow-ups still needed for the charts to actually split
- [ ] **Looker side** — update the Run chart explore/look to pivot/group by `category`. Without this, the column ships but charts look identical.
- [ ] **Backfill historical rows** — existing rows default to `Functional`. Run a one-time `UPDATE report_testrail_test_runs SET category = ...` based on `name` if historical splits matter for the dashboard.
- [ ] **Verify classification source** — current rule reads `run.name`. Existing L10n detection in `api/testrail/report_test_results.py` reads the **plan** name (`tp.name`). If L10n runs don't carry `L10N` in their own name, they'll fall through to `Functional` — worth eyeballing the first day of ingest and switching to plan-name (or both) if needed.

## Test plan
- [ ] Schema applies cleanly to a fresh DB
- [ ] Run an ingest against a TestRail project; spot-check that rows in `report_testrail_test_runs` get the right `category`
- [ ] Confirm Smoke / L10n / Functional row counts match expectations vs. TestRail UI
- [ ] Once Looker is updated, confirm the three-series chart renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)