### PR TITLE
Upgrade Python to 3.14 across all remaining workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python environment
         uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version: "3.14"
 
       - name: flake8 Lint
         uses: py-actions/flake8@v2

--- a/.github/workflows/production-daily-desktop.yaml
+++ b/.github/workflows/production-daily-desktop.yaml
@@ -35,6 +35,8 @@ jobs:
 
       - name: Setup python
         uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
 
       - name: Establish Cloud SQL Proxy
         uses: mattes/gce-cloudsql-proxy-action@v1

--- a/.github/workflows/production-daily-softvision-teams.yaml
+++ b/.github/workflows/production-daily-softvision-teams.yaml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Setup python
         uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
 
       - name: Establish Cloud SQL Proxy
         uses: mattes/gce-cloudsql-proxy-action@v1

--- a/.github/workflows/production-daily.yml
+++ b/.github/workflows/production-daily.yml
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.11'
+          python-version: '3.14'
           cache: "pip"
           cache-dependency-path: requirements.txt
       - uses: mattes/gce-cloudsql-proxy-action@v1
@@ -82,7 +82,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.11'
+          python-version: '3.14'
           cache: "pip"
           cache-dependency-path: requirements.txt
       - uses: mattes/gce-cloudsql-proxy-action@v1

--- a/.github/workflows/production-weekly-desktop.yaml
+++ b/.github/workflows/production-weekly-desktop.yaml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Setup python
         uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
 
       - name: Establish Cloud SQL Proxy
         uses: mattes/gce-cloudsql-proxy-action@v1

--- a/.github/workflows/production-weekly-firefox-ios-deepdive.yaml
+++ b/.github/workflows/production-weekly-firefox-ios-deepdive.yaml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.13'
+          python-version: '3.14'
           cache: "pip"
           cache-dependency-path: requirements.txt
       - run: pip install -r requirements.txt

--- a/.github/workflows/production-weekly.yml
+++ b/.github/workflows/production-weekly.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup python 
         uses: actions/setup-python@v6
         with:
-          python-version: '3.11'
+          python-version: '3.14'
 
       - name: Establish Cloud SQL Proxy
         uses: mattes/gce-cloudsql-proxy-action@v1

--- a/.github/workflows/staging-daily-desktop.yml
+++ b/.github/workflows/staging-daily-desktop.yml
@@ -33,6 +33,8 @@ jobs:
 
       - name: Setup python
         uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
 
       - name: Establish Cloud SQL Proxy
         uses: mattes/gce-cloudsql-proxy-action@v1

--- a/.github/workflows/staging-daily-softvision-teams.yml
+++ b/.github/workflows/staging-daily-softvision-teams.yml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Setup python
         uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
 
       - name: Establish Cloud SQL Proxy
         uses: mattes/gce-cloudsql-proxy-action@v1

--- a/.github/workflows/staging-daily.yml
+++ b/.github/workflows/staging-daily.yml
@@ -64,7 +64,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.11'
+          python-version: '3.14'
           cache: "pip"
           cache-dependency-path: requirements.txt
       - uses: mattes/gce-cloudsql-proxy-action@v1
@@ -83,7 +83,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.11'
+          python-version: '3.14'
           cache: "pip"
           cache-dependency-path: requirements.txt
       - uses: mattes/gce-cloudsql-proxy-action@v1

--- a/.github/workflows/staging-weekly-desktop.yml
+++ b/.github/workflows/staging-weekly-desktop.yml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Setup python
         uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
 
       - name: Establish Cloud SQL Proxy
         uses: mattes/gce-cloudsql-proxy-action@v1

--- a/.github/workflows/staging-weekly.yml
+++ b/.github/workflows/staging-weekly.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.11'
+          python-version: '3.14'
           cache: "pip"
           cache-dependency-path: requirements.txt
       - run: pip install -r requirements.txt
@@ -74,7 +74,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.11'
+          python-version: '3.14'
           cache: "pip"
           cache-dependency-path: requirements.txt
       - uses: mattes/gce-cloudsql-proxy-action@v1

--- a/.github/workflows/unit-tests-daily.yml
+++ b/.github/workflows/unit-tests-daily.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python environment
         uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version: "3.14"
 
       - name: Install dependencies
         run: pip install -r requirements.txt

--- a/.github/workflows/utilities-weekly.yml
+++ b/.github/workflows/utilities-weekly.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup python 
         uses: actions/setup-python@v6
         with:
-          python-version: '3.11'
+          python-version: '3.14'
 
       - name: Establish Cloud SQL Proxy
         uses: mattes/gce-cloudsql-proxy-action@v1


### PR DESCRIPTION
[Numpy `2.5.0` dropped support for Python 3.11 ](https://numpy.org/devdocs/release/2.5.0-notes.html) so workflows that target `3.11` and install `requirements.txt` will fail-out. Let's just target Python `3.14` across all workflows and those that didn't specify, let's specify so we know which they are using.