### PR TITLE
Force REST backend on python-bugzilla client

### DIFF
--- a/api/bugzilla/api_bugzilla.py
+++ b/api/bugzilla/api_bugzilla.py
@@ -698,8 +698,10 @@ class BugzillaClient(Bugz):
             # Create the DataFrame
             df = pd.DataFrame(rows)
 
-            df['modification_date'] = pd.to_datetime(df['modification_date'], format='%Y%m%dT%H:%M:%S') # noqa
-            df['creation_date'] = pd.to_datetime(df['creation_date'], format='%Y%m%dT%H:%M:%S') # noqa
+            # REST returns ISO 8601 (2026-07-22T19:54:17Z); XMLRPC used
+            # the compact 20260722T19:54:17 form. Accept ISO 8601.
+            df['modification_date'] = pd.to_datetime(df['modification_date'], format='ISO8601') # noqa
+            df['creation_date'] = pd.to_datetime(df['creation_date'], format='ISO8601') # noqa
 
             # Drop the columns 'type_id' and 'id'
             df_cleaned = df.drop(columns=["type_id", "id"])
@@ -922,9 +924,16 @@ class DatabaseBugzilla(Database):
 
                 if existing:
                     print(f"Updating bug {bug_id}")
-                    # Compare last_change_time to update
-                    last_change_remote = pd.to_datetime(row['last_change_time'])
-                    if last_change_remote > existing.bugzilla_bug_last_change_time:
+                    # Compare last_change_time to update.
+                    # REST returns tz-aware timestamps; MySQL DATETIME
+                    # comes back tz-naive. Normalize both sides.
+                    last_change_remote = DatetimeUtils.to_naive_utc(
+                        row['last_change_time']
+                    )
+                    last_change_existing = DatetimeUtils.to_naive_utc(
+                        existing.bugzilla_bug_last_change_time
+                    )
+                    if last_change_remote > last_change_existing:
                         existing.bugzilla_summary = row['summary']
                         existing.bugzilla_product = row['product']
                         existing.bugzilla_qa_whiteboard = row['qa_whiteboard']

--- a/lib/bugzilla_conn.py
+++ b/lib/bugzilla_conn.py
@@ -31,8 +31,10 @@ class BugzillaAPIClient:
         if not self.key:
             raise Exception("Missing BUGZILLA_API_KEY")
         if self.key:
+            # Force REST backend; XMLRPC is being decommissioned by BMO.
             self.bz_client = with_retry(
                 bugzilla.Bugzilla,
                 self.URL,
                 api_key=self.key,
+                force_rest=True,
             )


### PR DESCRIPTION
BMO is decommissioning the XMLRPC API; this bot account is the heaviest remaining user (~1500 calls / 30 days). `force_rest=True` switches transport without touching any callsite — python-bugzilla abstracts the difference between XMLRPC and REST.