### PR TITLE
Rounding crash free rates

### DIFF
--- a/api/sentry/api_sentry.py
+++ b/api/sentry/api_sentry.py
@@ -556,17 +556,13 @@ class DatabaseSentry:
         # Let me use -1 to indicate null values
         percentage_crash_free_rate_session = -1
         if crash_free_rate_session:
-            percentage_crash_free_rate_session = round(
-                crash_free_rate_session * 100, 2
-            )
+            percentage_crash_free_rate_session = crash_free_rate_session * 100
         percentage_crash_free_rate_user = -1
         if crash_free_rate_user:
-            percentage_crash_free_rate_user = round(
-                crash_free_rate_user * 100, 2
-            )
+            percentage_crash_free_rate_user = crash_free_rate_user * 100
         percentage_adoption_rate_user = -1
         if adoption_rate_user is not None:
-            percentage_adoption_rate_user = round(adoption_rate_user, 2)
+            percentage_adoption_rate_user = adoption_rate_user
 
         now = datetime.now()
         row = [

--- a/api/sentry/utils.py
+++ b/api/sentry/utils.py
@@ -100,15 +100,15 @@ def insert_rates(json_data, csv_file, project, shortform=False):
             if float(row['adoption_rate_user']) > 1:
                 crash_free_rate_user = (
                     "NaN" if float(row['crash_free_rate_user']) < 0
-                    else row['crash_free_rate_user']
+                    else f"{float(row['crash_free_rate_user']):.2f}"
                 )
                 crash_free_rate_session = (
                     "NaN" if float(row['crash_free_rate_session']) < 0
-                    else row['crash_free_rate_session']
+                    else f"{float(row['crash_free_rate_session']):.4f}"
                 )
                 adoption_rate_user = (
                     "NaN" if float(row['adoption_rate_user']) < 0
-                    else row['adoption_rate_user']
+                    else f"{float(row['adoption_rate_user']):.4f}"
                 )
                 release_version = row['release_version']
                 if all_future_versions is not None:

--- a/api/sentry/utils.py
+++ b/api/sentry/utils.py
@@ -100,7 +100,7 @@ def insert_rates(json_data, csv_file, project, shortform=False):
             if float(row['adoption_rate_user']) > 1:
                 crash_free_rate_user = (
                     "NaN" if float(row['crash_free_rate_user']) < 0
-                    else f"{float(row['crash_free_rate_user']):.2f}"
+                    else f"{float(row['crash_free_rate_user']):.4f}"
                 )
                 crash_free_rate_session = (
                     "NaN" if float(row['crash_free_rate_session']) < 0
@@ -108,7 +108,7 @@ def insert_rates(json_data, csv_file, project, shortform=False):
                 )
                 adoption_rate_user = (
                     "NaN" if float(row['adoption_rate_user']) < 0
-                    else f"{float(row['adoption_rate_user']):.4f}"
+                    else f"{float(row['adoption_rate_user']):.2f}"
                 )
                 release_version = row['release_version']
                 if all_future_versions is not None:


### PR DESCRIPTION
* Store unrounded values in the database
* Use 4 decimal places for crash free rate values just for the Slack notifications.
<img width="511" height="234" alt="Screenshot 2026-07-27 at 13 47 54" src="https://github.com/user-attachments/assets/3f1fcb95-00fc-48ae-aec9-f0351e4a78f1" />

<img width="507" height="240" alt="Screenshot 2026-07-27 at 13 49 48" src="https://github.com/user-attachments/assets/51c5e594-2900-43f2-b87f-60bc20371086" />
<img width="526" height="123" alt="Screenshot 2026-07-27 at 13 51 55" src="https://github.com/user-attachments/assets/f1f93320-0a89-42e0-af37-208a4b41e0fe" />
