### PR TITLE
Fix duplicate release version rows in Sentry rates

### DIFF
--- a/.github/workflows/staging-daily.yml
+++ b/.github/workflows/staging-daily.yml
@@ -104,14 +104,6 @@ jobs:
           python -m api.sentry.utils --file ./sentry_rates.csv --project firefox-ios
           ls sentry-slack-firefox-ios.json
 
-      - name: Send Sentry rates to Slack sandbox (iOS)
-        uses: slackapi/slack-github-action@v3.0.3
-        with:
-          payload-file-path: "./sentry-slack-firefox-ios.json"
-          payload-templated: true
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL_TEST_ALERTS_SANDBOX }}
-          webhook-type: incoming-webhook
-
       - name: Sentry query (Android)
         run: |
           python __main__.py --report-type sentry-issues --project fenix
@@ -121,14 +113,6 @@ jobs:
           python -m api.sentry.utils --file ./sentry_rates.csv --project fenix
           ls sentry-slack-fenix.json
 
-      - name: Send Sentry rates to Slack sandbox (Android)
-        uses: slackapi/slack-github-action@v3.0.3
-        with:
-          payload-file-path: "./sentry-slack-fenix.json"
-          payload-templated: true
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL_TEST_ALERTS_SANDBOX }}
-          webhook-type: incoming-webhook
-
       - name: Sentry query (Android Beta)
         run: |
           python __main__.py --report-type sentry-issues --project fenix-beta
@@ -137,14 +121,6 @@ jobs:
         run: |
           python -m api.sentry.utils --file ./sentry_rates.csv --project fenix-beta
           ls sentry-slack-fenix-beta.json
-
-      - name: Send Sentry rates to Slack sandbox (Android Beta)
-        uses: slackapi/slack-github-action@v3.0.3
-        with:
-          payload-file-path: "./sentry-slack-fenix-beta.json"
-          payload-templated: true
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL_TEST_ALERTS_SANDBOX }}
-          webhook-type: incoming-webhook
 
       - name: Notify Slack on any type of failure
         if: failure()

--- a/.github/workflows/staging-daily.yml
+++ b/.github/workflows/staging-daily.yml
@@ -104,6 +104,14 @@ jobs:
           python -m api.sentry.utils --file ./sentry_rates.csv --project firefox-ios
           ls sentry-slack-firefox-ios.json
 
+      - name: Send Sentry rates to Slack sandbox (iOS)
+        uses: slackapi/slack-github-action@v3.0.3
+        with:
+          payload-file-path: "./sentry-slack-firefox-ios.json"
+          payload-templated: true
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL_TEST_ALERTS_SANDBOX }}
+          webhook-type: incoming-webhook
+
       - name: Sentry query (Android)
         run: |
           python __main__.py --report-type sentry-issues --project fenix
@@ -113,6 +121,14 @@ jobs:
           python -m api.sentry.utils --file ./sentry_rates.csv --project fenix
           ls sentry-slack-fenix.json
 
+      - name: Send Sentry rates to Slack sandbox (Android)
+        uses: slackapi/slack-github-action@v3.0.3
+        with:
+          payload-file-path: "./sentry-slack-fenix.json"
+          payload-templated: true
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL_TEST_ALERTS_SANDBOX }}
+          webhook-type: incoming-webhook
+
       - name: Sentry query (Android Beta)
         run: |
           python __main__.py --report-type sentry-issues --project fenix-beta
@@ -121,6 +137,14 @@ jobs:
         run: |
           python -m api.sentry.utils --file ./sentry_rates.csv --project fenix-beta
           ls sentry-slack-fenix-beta.json
+
+      - name: Send Sentry rates to Slack sandbox (Android Beta)
+        uses: slackapi/slack-github-action@v3.0.3
+        with:
+          payload-file-path: "./sentry-slack-fenix-beta.json"
+          payload-templated: true
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL_TEST_ALERTS_SANDBOX }}
+          webhook-type: incoming-webhook
 
       - name: Notify Slack on any type of failure
         if: failure()

--- a/api/sentry/api_sentry.py
+++ b/api/sentry/api_sentry.py
@@ -454,8 +454,21 @@ class SentryClient(Sentry):
 
         payload.sort(key=Version, reverse=True)
 
+        # A version can be respun with a higher buildCode; the sort above
+        # puts the highest buildCode first, so keep only the first
+        # occurrence of each version (without its build suffix) to drop
+        # the older respins.
+        seen = set()
+        deduped = []
+        for raw_version in payload:
+            short_version = raw_version.split('+')[0]
+            if short_version in seen:
+                continue
+            seen.add(short_version)
+            deduped.append(raw_version)
+
         # Just a list of released versions, not a dataframe
-        return payload
+        return deduped
 
 
 class DatabaseSentry:


### PR DESCRIPTION
Sentry could return multiple versions from fenix because a dot release could be respun. Let me take the highest build number among the dot versions.
Before:
<img width="587" height="235" alt="Screenshot 2026-07-27 at 14 37 44" src="https://github.com/user-attachments/assets/d8b310b5-fbb7-467b-894f-19079c2acf88" />
After:
<img width="515" height="207" alt="Screenshot 2026-07-27 at 14 37 48" src="https://github.com/user-attachments/assets/3267c225-d923-49d2-8185-917d73403bfb" />

Test in Github Actions. Note that no duplicated (dot) releases are used:
https://github.com/mozilla-mobile/testops-dashboard/actions/runs/30298197756/job/90084328975
```
crash_free_rate_user                            99.98
crash_free_rate_session                         100.0
adoption_rate_user                              71.58
release_version                                 153.0
created_at                 2026-07-27 19:35:04.157206
sentry_project_id                             ***
Name: 0, dtype: object
crash_free_rate_user                            99.99
crash_free_rate_session                         100.0
adoption_rate_user                              16.15
release_version                               152.0.6
created_at                 2026-07-27 19:35:10.974492
sentry_project_id                             ***
Name: 0, dtype: object
crash_free_rate_user                            99.99
crash_free_rate_session                         100.0
adoption_rate_user                               2.88
release_version                               152.0.5
created_at                 2026-07-27 19:35:15.586358
sentry_project_id                             ***
Name: 0, dtype: object
crash_free_rate_user                            99.99
crash_free_rate_session                         100.0
adoption_rate_user                               1.68
release_version                               152.0.4
created_at                 2026-07-27 19:35:20.314280
sentry_project_id                             ***
Name: 0, dtype: object
crash_free_rate_user                            99.98
crash_free_rate_session                         100.0
adoption_rate_user                               1.19
release_version                               152.0.2
created_at                 2026-07-27 19:35:25.479006
sentry_project_id                             ***
Name: 0, dtype: object
crash_free_rate_user                            99.99
crash_free_rate_session                         100.0
adoption_rate_user                               0.58
release_version                               152.0.1
created_at                 2026-07-27 19:35:30.583225
sentry_project_id                             ***
Name: 0, dtype: object
crash_free_rate_user                            99.98
crash_free_rate_session                         100.0
adoption_rate_user                               0.08
release_version                                 152.0
created_at                 2026-07-27 19:35:34.475828
sentry_project_id                             ***

```