### PR TITLE
Bugfix: Truncate crash free rates to 4 decimal places

### DIFF
--- a/.github/workflows/staging-daily.yml
+++ b/.github/workflows/staging-daily.yml
@@ -100,27 +100,60 @@ jobs:
           python __main__.py --report-type sentry-rates --project firefox-ios
 
       - name: Construct JSON for Slack (iOS)
+        id: construct-json-firefox-ios
         run: |
           python -m api.sentry.utils --file ./sentry_rates.csv --project firefox-ios
           ls sentry-slack-firefox-ios.json
+          echo "has_data=$([ $(wc -l < sentry_rates.csv) -gt 1 ] && echo true || echo false)" >> $GITHUB_OUTPUT
+
+      - name: Send health notification to Slack sandbox (iOS)
+        if: steps.construct-json-firefox-ios.outputs.has_data == 'true'
+        uses: slackapi/slack-github-action@v3.0.5
+        with:
+          payload-file-path: "./sentry-slack-firefox-ios.json"
+          payload-templated: true
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL_TEST_ALERTS_SANDBOX }}
+          webhook-type: incoming-webhook
 
       - name: Sentry query (Android)
         run: |
           python __main__.py --report-type sentry-issues --project fenix
           python __main__.py --report-type sentry-rates --project fenix
       - name: Construct JSON for Slack (Android)
+        id: construct-json-fenix
         run: |
           python -m api.sentry.utils --file ./sentry_rates.csv --project fenix
           ls sentry-slack-fenix.json
+          echo "has_data=$([ $(wc -l < sentry_rates.csv) -gt 1 ] && echo true || echo false)" >> $GITHUB_OUTPUT
+
+      - name: Send health notification to Slack sandbox (Android)
+        if: steps.construct-json-fenix.outputs.has_data == 'true'
+        uses: slackapi/slack-github-action@v3.0.5
+        with:
+          payload-file-path: "./sentry-slack-fenix.json"
+          payload-templated: true
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL_TEST_ALERTS_SANDBOX }}
+          webhook-type: incoming-webhook
 
       - name: Sentry query (Android Beta)
         run: |
           python __main__.py --report-type sentry-issues --project fenix-beta
           python __main__.py --report-type sentry-rates --project fenix-beta
       - name: Construct JSON for Slack (Android Beta)
+        id: construct-json-fenix-beta
         run: |
           python -m api.sentry.utils --file ./sentry_rates.csv --project fenix-beta
           ls sentry-slack-fenix-beta.json
+          echo "has_data=$([ $(wc -l < sentry_rates.csv) -gt 1 ] && echo true || echo false)" >> $GITHUB_OUTPUT
+
+      - name: Send health notification to Slack sandbox (Android Beta)
+        if: steps.construct-json-fenix-beta.outputs.has_data == 'true'
+        uses: slackapi/slack-github-action@v3.0.5
+        with:
+          payload-file-path: "./sentry-slack-fenix-beta.json"
+          payload-templated: true
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL_TEST_ALERTS_SANDBOX }}
+          webhook-type: incoming-webhook
 
       - name: Notify Slack on any type of failure
         if: failure()

--- a/.github/workflows/staging-daily.yml
+++ b/.github/workflows/staging-daily.yml
@@ -106,15 +106,6 @@ jobs:
           ls sentry-slack-firefox-ios.json
           echo "has_data=$([ $(wc -l < sentry_rates.csv) -gt 1 ] && echo true || echo false)" >> $GITHUB_OUTPUT
 
-      - name: Send health notification to Slack sandbox (iOS)
-        if: steps.construct-json-firefox-ios.outputs.has_data == 'true'
-        uses: slackapi/slack-github-action@v3.0.5
-        with:
-          payload-file-path: "./sentry-slack-firefox-ios.json"
-          payload-templated: true
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL_TEST_ALERTS_SANDBOX }}
-          webhook-type: incoming-webhook
-
       - name: Sentry query (Android)
         run: |
           python __main__.py --report-type sentry-issues --project fenix
@@ -126,15 +117,6 @@ jobs:
           ls sentry-slack-fenix.json
           echo "has_data=$([ $(wc -l < sentry_rates.csv) -gt 1 ] && echo true || echo false)" >> $GITHUB_OUTPUT
 
-      - name: Send health notification to Slack sandbox (Android)
-        if: steps.construct-json-fenix.outputs.has_data == 'true'
-        uses: slackapi/slack-github-action@v3.0.5
-        with:
-          payload-file-path: "./sentry-slack-fenix.json"
-          payload-templated: true
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL_TEST_ALERTS_SANDBOX }}
-          webhook-type: incoming-webhook
-
       - name: Sentry query (Android Beta)
         run: |
           python __main__.py --report-type sentry-issues --project fenix-beta
@@ -145,44 +127,3 @@ jobs:
           python -m api.sentry.utils --file ./sentry_rates.csv --project fenix-beta
           ls sentry-slack-fenix-beta.json
           echo "has_data=$([ $(wc -l < sentry_rates.csv) -gt 1 ] && echo true || echo false)" >> $GITHUB_OUTPUT
-
-      - name: Send health notification to Slack sandbox (Android Beta)
-        if: steps.construct-json-fenix-beta.outputs.has_data == 'true'
-        uses: slackapi/slack-github-action@v3.0.5
-        with:
-          payload-file-path: "./sentry-slack-fenix-beta.json"
-          payload-templated: true
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL_TEST_ALERTS_SANDBOX }}
-          webhook-type: incoming-webhook
-
-      - name: Notify Slack on any type of failure
-        if: failure()
-        uses: slackapi/slack-github-action@v3.0.5
-        with:
-          payload: |
-            {
-              "text": ":x: *Sentry report failed*\nWorkflow: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }} #${{ github.run_number }}>",
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": ":x: *Sentry report failed*\nWorkflow: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }} #${{ github.run_number }}>"
-                  }
-                },
-                {
-                  "type": "divider"
-                },
-                {
-                  "type": "context",
-                  "elements": [
-                    {
-                      "type": "mrkdwn",
-                      "text": ":testops-notify: Created by Mobile Test Engineering"
-                    }
-                  ]
-                }
-              ]
-            }
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL_TEST_ALERTS_SANDBOX }}
-          webhook-type: incoming-webhook

--- a/api/sentry/utils.py
+++ b/api/sentry/utils.py
@@ -1,6 +1,7 @@
 import json
 import csv
 import argparse
+import math
 import tomllib
 from pathlib import Path
 from urllib.parse import urlencode
@@ -39,6 +40,13 @@ def format_count(value) -> str:
     if n < 1000:
         return str(n)
     return f"{round(n / 1000)}k"
+
+
+def truncate(value: float, decimals: int) -> str:
+    """Truncate (not round) a float to the given number of decimal places."""
+    factor = 10 ** decimals
+    truncated = math.floor(value * factor) / factor
+    return f"{truncated:.{decimals}f}"
 
 
 def package_for(project: str) -> str:
@@ -100,11 +108,11 @@ def insert_rates(json_data, csv_file, project, shortform=False):
             if float(row['adoption_rate_user']) > 1:
                 crash_free_rate_user = (
                     "NaN" if float(row['crash_free_rate_user']) < 0
-                    else f"{float(row['crash_free_rate_user']):.4f}"
+                    else truncate(float(row['crash_free_rate_user']), 4)
                 )
                 crash_free_rate_session = (
                     "NaN" if float(row['crash_free_rate_session']) < 0
-                    else f"{float(row['crash_free_rate_session']):.4f}"
+                    else truncate(float(row['crash_free_rate_session']), 4)
                 )
                 adoption_rate_user = (
                     "NaN" if float(row['adoption_rate_user']) < 0


### PR DESCRIPTION
Even with 4 decimal places, the rates may round up to 100%, which is misleading.

Sample reports: https://mozilla.slack.com/archives/C016BC5FUHJ/p1786467642558629
<img width="400" alt="Screenshot 2026-08-11 at 13 47 00" src="https://github.com/user-attachments/assets/a2456bce-262a-4039-a934-9f3d6300bb9b" />
<img width="400" alt="Screenshot 2026-08-11 at 13 47 04" src="https://github.com/user-attachments/assets/d11c44aa-5161-40e8-bba7-cdcb44ff21ea" />
